### PR TITLE
fix arena cleanup, team spawns, join/leave, and generators

### DIFF
--- a/src/main/java/com/example/bedwars/arena/ArenaManager.java
+++ b/src/main/java/com/example/bedwars/arena/ArenaManager.java
@@ -35,7 +35,18 @@ public class ArenaManager {
     }
 
     public void delete(String name){
-        arenas.remove(name.toLowerCase());
+        Arena removed = arenas.remove(name.toLowerCase());
+        if (removed != null){
+            for (org.bukkit.World w : org.bukkit.Bukkit.getWorlds()){
+                for (org.bukkit.entity.Entity ent : w.getEntities()){
+                    var pdc = ent.getPersistentDataContainer();
+                    if (pdc.has(Keys.ARENA, org.bukkit.persistence.PersistentDataType.STRING)){
+                        String tag = pdc.get(Keys.ARENA, org.bukkit.persistence.PersistentDataType.STRING);
+                        if (name.equalsIgnoreCase(tag)) ent.remove();
+                    }
+                }
+            }
+        }
         File f = new File(plugin.getDataFolder(), "arenas/"+name+".yml");
         if (f.exists()) f.delete();
     }
@@ -138,7 +149,9 @@ public class ArenaManager {
             org.bukkit.entity.Villager v = item.getWorld().spawn(item, org.bukkit.entity.Villager.class);
             v.setAI(false); v.setInvulnerable(true); v.setSilent(true); v.setCollidable(false);
             v.setCustomName("§bBoutique"); v.setCustomNameVisible(true);
-            v.getPersistentDataContainer().set(Keys.NPC, org.bukkit.persistence.PersistentDataType.STRING, "item");
+            var pdc = v.getPersistentDataContainer();
+            pdc.set(Keys.NPC, org.bukkit.persistence.PersistentDataType.STRING, "item");
+            pdc.set(Keys.ARENA, org.bukkit.persistence.PersistentDataType.STRING, a.getName());
             v.teleport(item);
         }
         var up = a.getUpgradeShop();
@@ -147,7 +160,9 @@ public class ArenaManager {
             org.bukkit.entity.Villager v = up.getWorld().spawn(up, org.bukkit.entity.Villager.class);
             v.setAI(false); v.setInvulnerable(true); v.setSilent(true); v.setCollidable(false);
             v.setCustomName("§eAméliorations"); v.setCustomNameVisible(true);
-            v.getPersistentDataContainer().set(Keys.NPC, org.bukkit.persistence.PersistentDataType.STRING, "upgrade");
+            var pdc = v.getPersistentDataContainer();
+            pdc.set(Keys.NPC, org.bukkit.persistence.PersistentDataType.STRING, "upgrade");
+            pdc.set(Keys.ARENA, org.bukkit.persistence.PersistentDataType.STRING, a.getName());
             v.teleport(up);
         }
         for (Generator g : a.getGenerators()){
@@ -157,7 +172,9 @@ public class ArenaManager {
             org.bukkit.entity.ArmorStand as = loc.getWorld().spawn(loc.clone().add(0,0.1,0), org.bukkit.entity.ArmorStand.class);
             as.setInvisible(true); as.setMarker(true); as.setGravity(false);
             as.setCustomName("§bGEN §7: §f" + g.getType().name()); as.setCustomNameVisible(true);
-            as.getPersistentDataContainer().set(Keys.GEN, org.bukkit.persistence.PersistentDataType.STRING, g.getType().name());
+            var pdc = as.getPersistentDataContainer();
+            pdc.set(Keys.GEN, org.bukkit.persistence.PersistentDataType.STRING, g.getType().name());
+            pdc.set(Keys.ARENA, org.bukkit.persistence.PersistentDataType.STRING, a.getName());
         }
     }
 

--- a/src/main/java/com/example/bedwars/commands/BwCommand.java
+++ b/src/main/java/com/example/bedwars/commands/BwCommand.java
@@ -52,7 +52,15 @@ public class BwCommand implements CommandExecutor, TabCompleter {
             case "leave":
                 if (!(sender instanceof Player p2)) return true;
                 plugin.arenas().all().forEach(ar->ar.removePlayer(p2.getUniqueId()));
-                p2.getInventory().clear(); p2.sendMessage(C.msg("arena.leave")); return true;
+                p2.getInventory().clear();
+                org.bukkit.World w = org.bukkit.Bukkit.getWorld(plugin.getConfig().getString("lobby-world", "world"));
+                if (w != null) p2.teleport(w.getSpawnLocation());
+                org.bukkit.inventory.ItemStack compass = new org.bukkit.inventory.ItemStack(org.bukkit.Material.COMPASS);
+                org.bukkit.inventory.meta.ItemMeta meta = compass.getItemMeta();
+                meta.setDisplayName("§bMenu BedWars"); compass.setItemMeta(meta);
+                p2.getInventory().setItem(0, compass);
+                p2.setScoreboard(org.bukkit.Bukkit.getScoreboardManager().getMainScoreboard());
+                p2.sendMessage(C.msg("arena.leave")); return true;
         }
         return true;
     }

--- a/src/main/java/com/example/bedwars/listeners/MenuListener.java
+++ b/src/main/java/com/example/bedwars/listeners/MenuListener.java
@@ -72,6 +72,13 @@ public class MenuListener implements Listener {
                 UUID id = p.getUniqueId();
                 arenas.all().forEach(a -> a.removePlayer(id));
                 p.getInventory().clear();
+                org.bukkit.World w = org.bukkit.Bukkit.getWorld(plugin.getConfig().getString("lobby-world", "world"));
+                if (w != null) p.teleport(w.getSpawnLocation());
+                org.bukkit.inventory.ItemStack compass = new org.bukkit.inventory.ItemStack(org.bukkit.Material.COMPASS);
+                org.bukkit.inventory.meta.ItemMeta meta1 = compass.getItemMeta();
+                meta1.setDisplayName("§bMenu BedWars"); compass.setItemMeta(meta1);
+                p.getInventory().setItem(0, compass);
+                p.setScoreboard(org.bukkit.Bukkit.getScoreboardManager().getMainScoreboard());
                 p.sendMessage(C.msg("arena.leave"));
             }
             case "OPEN_SHOP" -> plugin.shops().open(p);
@@ -152,25 +159,28 @@ public class MenuListener implements Listener {
                 Location gl = p.getLocation().getBlock().getLocation().add(0.5, 0, 0.5);
                 a.getGenerators().add(new Generator(gt, gl, 1));
                 arenas.save(a);
+                plugin.generators().resetArena(a);
                 ArmorStand as = gl.getWorld().spawn(gl.clone().add(0, 0.1, 0), ArmorStand.class);
                 as.setInvisible(true); as.setMarker(true); as.setGravity(false);
                 as.setCustomName("§bGEN §7: §f" + gt.name()); as.setCustomNameVisible(true);
-                as.getPersistentDataContainer().set(GEN_KEY, PersistentDataType.STRING, gt.name());
+                var pdc = as.getPersistentDataContainer();
+                pdc.set(GEN_KEY, PersistentDataType.STRING, gt.name());
+                pdc.set(Keys.ARENA, PersistentDataType.STRING, arenaName);
                 p.sendMessage(C.color("&aGénérateur " + gt.name() + " ajouté."));
                 menus.openArenaEditor(p, arenaName);
             }
             case "SET_SHOP_ITEM" -> {
                 Arena a = arenas.get(arenaName);
                 if (a == null) return;
-                Location loc = p.getLocation().getBlock().getLocation().add(0.5, 0, 0.5);
-                loc.setYaw(p.getLocation().getYaw());
-                loc.setPitch(0f);
+                Location loc = p.getLocation().clone();
                 a.setItemShop(loc);
                 arenas.save(a);
                 Villager v = loc.getWorld().spawn(loc, Villager.class);
                 v.setAI(false); v.setInvulnerable(true); v.setSilent(true); v.setCollidable(false);
                 v.setCustomName("§bBoutique"); v.setCustomNameVisible(true);
-                v.getPersistentDataContainer().set(NPC_KEY, PersistentDataType.STRING, "item");
+                var pdc = v.getPersistentDataContainer();
+                pdc.set(NPC_KEY, PersistentDataType.STRING, "item");
+                pdc.set(Keys.ARENA, PersistentDataType.STRING, arenaName);
                 v.teleport(loc);
                 p.sendMessage(C.color("&aBoutique d'objets définie et PNJ posé."));
                 menus.openArenaEditor(p, arenaName);
@@ -178,15 +188,15 @@ public class MenuListener implements Listener {
             case "SET_SHOP_UPGRADE" -> {
                 Arena a = arenas.get(arenaName);
                 if (a == null) return;
-                Location loc = p.getLocation().getBlock().getLocation().add(0.5, 0, 0.5);
-                loc.setYaw(p.getLocation().getYaw());
-                loc.setPitch(0f);
+                Location loc = p.getLocation().clone();
                 a.setUpgradeShop(loc);
                 arenas.save(a);
                 Villager v = loc.getWorld().spawn(loc, Villager.class);
                 v.setAI(false); v.setInvulnerable(true); v.setSilent(true); v.setCollidable(false);
                 v.setCustomName("§eAméliorations"); v.setCustomNameVisible(true);
-                v.getPersistentDataContainer().set(NPC_KEY, PersistentDataType.STRING, "upgrade");
+                var pdc = v.getPersistentDataContainer();
+                pdc.set(NPC_KEY, PersistentDataType.STRING, "upgrade");
+                pdc.set(Keys.ARENA, PersistentDataType.STRING, arenaName);
                 v.teleport(loc);
                 p.sendMessage(C.color("&aBoutique améliorations définie et PNJ posé."));
                 menus.openArenaEditor(p, arenaName);

--- a/src/main/java/com/example/bedwars/ui/MenuManager.java
+++ b/src/main/java/com/example/bedwars/ui/MenuManager.java
@@ -94,7 +94,6 @@ public class MenuManager {
         for (TeamColor t : TeamColor.values()){
             boolean hide=false; Arena a=arenas.get(arena);
             if (a!=null){
-                if (act.equals("SET_SPAWN") && a.hasSpawn(t)) hide=true;
                 if (act.equals("SET_BED") && a.hasBed(t)) hide=true;
                 if (act.equals("JOIN_TEAM") && (!a.isTeamEnabled(t) || a.getSpawn(t)==null)) hide=true;
             }

--- a/src/main/java/com/example/bedwars/util/Keys.java
+++ b/src/main/java/com/example/bedwars/util/Keys.java
@@ -9,5 +9,7 @@ public final class Keys {
     public static final NamespacedKey NPC = new NamespacedKey(BedwarsPlugin.get(), "bw_npc");
     /** Tag for generator marker armor stands. */
     public static final NamespacedKey GEN = new NamespacedKey(BedwarsPlugin.get(), "bw_gen");
+    /** Tag storing arena name for any entity related to an arena. */
+    public static final NamespacedKey ARENA = new NamespacedKey(BedwarsPlugin.get(), "bw_arena");
     private Keys() {}
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,8 +3,8 @@ countdown-seconds: 20
 max-team-size: 4
 teams-enabled: [RED, BLUE, GREEN, YELLOW]
 generators:
-  IRON: { interval: 20, amount: 1 }
-  GOLD: { interval: 120, amount: 1 }
-  DIAMOND: { interval: 600, amount: 1 }
-  EMERALD: { interval: 1200, amount: 1 }
+  IRON: { interval: 120, amount: 1 }   # ~6s
+  GOLD: { interval: 300, amount: 1 }   # ~15s
+  DIAMOND: { interval: 900, amount: 1 }   # ~45s
+  EMERALD: { interval: 1800, amount: 1 }   # ~90s
 block-protection: true


### PR DESCRIPTION
## Summary
- tag NPCs and generator markers with their arena and spawn them at the player's exact spot
- purge arena NPCs and markers on arena deletion and allow re-setting team spawns
- return players to lobby with compass on leave and slow generators to drop diamond/emerald

## Testing
- `mvn -q package` *(failed: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689af5b857d0832993c67e44a2959f24