### PR TITLE
docs: add architecture note and quick setup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,16 @@
+# Architecture BedWars
+
+Cette implémentation suit un modèle multi-arène et repose sur une machine à états simple.
+
+## Machine à états
+
+Chaque arène possède un `GameState` parmi `WAITING`, `STARTING`, `RUNNING`, `ENDING` et `RESTARTING`. Les transitions sont gérées par un `GameTicker` programmé chaque seconde. Il s'occupe des décomptes, de l'activation des générateurs et de la vérification des conditions de victoire.
+
+## Générateurs
+
+Les générateurs (fer, or, diamant, émeraude) sont des tâches déclenchées toutes les 20 ticks lorsque l'arène est en état `RUNNING`. Les délais et quantités proviennent de `config.yml` et peuvent évoluer selon les améliorations.
+
+## Réinitialisation de carte
+
+Par défaut, l'arène est rechargée à partir d'une copie de son monde lorsque la partie se termine. Si le plugin [SlimeWorldManager](https://github.com/Grinderwolf/Slime-World-Manager) est présent, un adaptateur spécialisé est utilisé pour accélérer le reset.
+

--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # Bedwars
 
-Plugin de démonstration BedWars pour Spigot/Paper 1.21.
+Plugin BedWars pour Spigot/Paper 1.21.
 
-### Notes de test
+## Mise en route rapide
+
+1. Compilez le plugin : `mvn -DskipTests package`.
+2. Copiez `target/bedwars-0.2.0.jar` dans le dossier `plugins/` de votre serveur 1.21.
+3. Démarrez le serveur puis utilisez `/bw` pour créer une arène :
+   - `/bw create <nom>` crée l'arène et en fait votre arène de configuration.
+   - Placez le lobby, les lits, spawns, générateurs et PNJ via les sous-commandes du menu.
+   - `/bw save` enregistre l'arène dans `plugins/Bedwars/arenas/`.
+4. Rejoignez l'arène avec `/bw join <nom>` et utilisez `/bw start` pour lancer la partie.
+5. À la fin, l'arène est automatiquement réinitialisée.
+
+## Notes de test
 
 1. Créer/éditer une arène avec `/bw` puis poser les générateurs et PNJ.
-2. Démarrer l'arène : les marqueurs « GEN: ... » de setup disparaissent.
+2. Démarrer l'arène : les marqueurs « GEN: ... » de setup disparaissent.
 3. Clic droit sur le PNJ « Améliorations » ouvre le menu dédié aux upgrades d'équipe.
 4. Acheter de la laine dans la boutique d'objets donne de la laine à la couleur de votre équipe.
 5. Le scoreboard ne liste que les équipes activées pour l'arène en cours.
+
+Pour plus de détails sur l'architecture et la machine à états, voir [ARCHITECTURE.md](ARCHITECTURE.md).


### PR DESCRIPTION
## Summary
- add quick start instructions for creating arenas and running games
- document machine state, generators and map reset logic in ARCHITECTURE.md

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b80c3e61483299594b66e98bcc087