### PR TITLE
Centralize Bedwars messages in configurable file

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -3,6 +3,7 @@ package com.example.bedwars;
 import com.example.bedwars.arena.ArenaManager;
 import com.example.bedwars.command.BedwarsCommand;
 import com.example.bedwars.listener.PlayerListener;
+import com.example.bedwars.util.MessageManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -14,10 +15,12 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class BedwarsPlugin extends JavaPlugin {
 
     private ArenaManager arenaManager;
+    private MessageManager messageManager;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
+        this.messageManager = new MessageManager(this);
         this.arenaManager = new ArenaManager(this);
 
         // Register command executor
@@ -29,5 +32,9 @@ public class BedwarsPlugin extends JavaPlugin {
 
     public ArenaManager getArenaManager() {
         return arenaManager;
+    }
+
+    public MessageManager getMessages() {
+        return messageManager;
     }
 }

--- a/src/main/java/com/example/bedwars/arena/Arena.java
+++ b/src/main/java/com/example/bedwars/arena/Arena.java
@@ -5,6 +5,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.Map;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -37,7 +39,7 @@ public class Arena {
 
     public void addPlayer(Player player) {
         players.add(player.getUniqueId());
-        player.sendMessage("§aVous avez rejoint l'arène " + name);
+        player.sendMessage(plugin.getMessages().get("arena.join", Map.of("arena", name)));
         if (state == GameState.WAITING && players.size() >= 2) {
             startCountdown();
         }
@@ -45,7 +47,7 @@ public class Arena {
 
     public void removePlayer(Player player) {
         players.remove(player.getUniqueId());
-        player.sendMessage("§cVous avez quitté l'arène " + name);
+        player.sendMessage(plugin.getMessages().get("arena.leave", Map.of("arena", name)));
         if (players.isEmpty() && state != GameState.WAITING) {
             reset();
         }
@@ -58,11 +60,11 @@ public class Arena {
             public void run() {
                 if (countdown <= 0) {
                     state = GameState.RUNNING;
-                    broadcast("§aDébut de la partie!");
+                    broadcast(plugin.getMessages().get("arena.started", Map.of("arena", name)));
                     cancel();
                     return;
                 }
-                broadcast("§eLa partie démarre dans " + countdown + "s");
+                broadcast(plugin.getMessages().get("start.countdown", Map.of("seconds", String.valueOf(countdown))));
                 countdown--;
             }
         }.runTaskTimer(plugin, 0L, 20L);

--- a/src/main/java/com/example/bedwars/arena/ArenaManager.java
+++ b/src/main/java/com/example/bedwars/arena/ArenaManager.java
@@ -47,7 +47,7 @@ public class ArenaManager {
 
     public void joinArena(Player player, String name) {
         getArena(name).ifPresentOrElse(arena -> arena.addPlayer(player),
-                () -> player.sendMessage("§cArène inconnue."));
+                () -> player.sendMessage(plugin.getMessages().get("error.no_arena")));
     }
 
     public void leaveArena(Player player) {

--- a/src/main/java/com/example/bedwars/command/BedwarsCommand.java
+++ b/src/main/java/com/example/bedwars/command/BedwarsCommand.java
@@ -6,6 +6,8 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import java.util.Map;
+
 /**
  * Very small command handler implementing only a subset of the
  * specification: list, join and leave. This is meant as a convenience
@@ -22,25 +24,26 @@ public class BedwarsCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player player)) {
-            sender.sendMessage("Commandes joueurs uniquement");
+            sender.sendMessage(plugin.getMessages().get("command.player-only"));
             return true;
         }
 
         if (args.length == 0 || args[0].equalsIgnoreCase("help")) {
-            player.sendMessage("§e/bw list§7 - liste des arènes");
-            player.sendMessage("§e/bw join <arène>§7 - rejoindre une arène");
-            player.sendMessage("§e/bw leave§7 - quitter l'arène");
+            player.sendMessage(plugin.getMessages().get("command.help.list"));
+            player.sendMessage(plugin.getMessages().get("command.help.join"));
+            player.sendMessage(plugin.getMessages().get("command.help.leave"));
             return true;
         }
 
         switch (args[0].toLowerCase()) {
             case "list" -> {
-                player.sendMessage("§aArènes disponibles: " + String.join(", ", plugin.getArenaManager().getArenas().keySet()));
+                String arenas = String.join(", ", plugin.getArenaManager().getArenas().keySet());
+                player.sendMessage(plugin.getMessages().get("command.list", Map.of("arenas", arenas)));
                 return true;
             }
             case "join" -> {
                 if (args.length < 2) {
-                    player.sendMessage("§cUsage: /bw join <arène>");
+                    player.sendMessage(plugin.getMessages().get("command.join-usage"));
                     return true;
                 }
                 plugin.getArenaManager().joinArena(player, args[1]);
@@ -51,7 +54,7 @@ public class BedwarsCommand implements CommandExecutor {
                 return true;
             }
             default -> {
-                player.sendMessage("§cSous-commande inconnue");
+                player.sendMessage(plugin.getMessages().get("command.unknown"));
                 return true;
             }
         }

--- a/src/main/java/com/example/bedwars/util/MessageManager.java
+++ b/src/main/java/com/example/bedwars/util/MessageManager.java
@@ -1,0 +1,62 @@
+package com.example.bedwars.util;
+
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * Loads and formats messages from the plugin's messages.yml file.
+ * Supports basic placeholder replacement using {placeholder} syntax.
+ */
+public class MessageManager {
+
+    private final JavaPlugin plugin;
+    private YamlConfiguration messages;
+
+    public MessageManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+        reload();
+    }
+
+    /**
+     * Reload messages.yml from disk.
+     */
+    public void reload() {
+        File file = new File(plugin.getDataFolder(), "messages.yml");
+        if (!file.exists()) {
+            plugin.saveResource("messages.yml", false);
+        }
+        this.messages = YamlConfiguration.loadConfiguration(file);
+    }
+
+    /**
+     * Fetch a message and apply color codes and placeholders.
+     *
+     * @param path         path in messages.yml
+     * @param placeholders map of placeholder -> value
+     * @return formatted message with prefix
+     */
+    public String get(String path, Map<String, String> placeholders) {
+        String prefix = messages.getString("prefix", "");
+        String msg = messages.getString(path, path);
+        if (!prefix.isEmpty()) {
+            msg = prefix + msg;
+        }
+        if (placeholders != null) {
+            for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+                msg = msg.replace("{" + entry.getKey() + "}", entry.getValue());
+            }
+        }
+        return ChatColor.translateAlternateColorCodes('&', msg);
+    }
+
+    /**
+     * Convenience overload without placeholders.
+     */
+    public String get(String path) {
+        return get(path, Map.of());
+    }
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -18,3 +18,12 @@ shop:
 start:
   countdown: "&eLa partie démarre dans &c{seconds}s"
   go: "&aGO!"
+command:
+  player-only: "&cCommandes joueurs uniquement"
+  help:
+    list: "&e/bw list&7 - liste des arènes"
+    join: "&e/bw join <arène>&7 - rejoindre une arène"
+    leave: "&e/bw leave&7 - quitter l'arène"
+  list: "&aArènes disponibles: &e{arenas}"
+  join-usage: "&cUsage: /bw join <arène>"
+  unknown: "&cSous-commande inconnue"


### PR DESCRIPTION
## Summary
- add `MessageManager` for prefix and placeholders
- route arena and command messages through messages.yml

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b881968ec8329b0fd25c1634c514a