### PR TITLE
Add basic admin command framework and GUI menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,17 @@ Ce plugin n'implémente pas encore l'ensemble des mécaniques BedWars
 (générateurs, boutiques, upgrades, scoreboard, etc.).
 Il constitue simplement une base sur laquelle bâtir.
 
+## Administration
+
+Un menu de gestion basique est disponible pour les joueurs possédant la
+permission `bedwars.admin`.
+
+* `/bw menu` (alias `/bw admin`, `/bw setup`) : ouvre la GUI de gestion.
+* `/bwadmin arena list` : liste les arènes chargées.
+* `/bwadmin arena create <id> <monde>` : crée une arène minimale.
+* `/bwadmin arena delete <id>` : supprime une arène et son fichier.
+
+Ces commandes ne couvrent qu'une petite partie du framework souhaité mais
+servent de point de départ pour l'étendre.
+
 Pour quelques notes d'architecture, voir [ARCHITECTURE.md](ARCHITECTURE.md).

--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -2,8 +2,10 @@ package com.example.bedwars;
 
 import com.example.bedwars.arena.ArenaManager;
 import com.example.bedwars.command.BedwarsCommand;
+import com.example.bedwars.command.AdminCommand;
 import com.example.bedwars.listener.PlayerListener;
 import com.example.bedwars.util.MessageManager;
+import com.example.bedwars.gui.AdminMenu;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -16,15 +18,20 @@ public class BedwarsPlugin extends JavaPlugin {
 
     private ArenaManager arenaManager;
     private MessageManager messageManager;
+    private AdminMenu adminMenu;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
         this.messageManager = new MessageManager(this);
         this.arenaManager = new ArenaManager(this);
+        this.adminMenu = new AdminMenu(this);
 
-        // Register command executor
+        // Register command executors
         getCommand("bw").setExecutor(new BedwarsCommand(this));
+        AdminCommand adminCmd = new AdminCommand(this);
+        getCommand("bwadmin").setExecutor(adminCmd);
+        getCommand("bwadmin").setTabCompleter(adminCmd);
 
         // Register basic listeners
         getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
@@ -36,5 +43,9 @@ public class BedwarsPlugin extends JavaPlugin {
 
     public MessageManager getMessages() {
         return messageManager;
+    }
+
+    public AdminMenu getAdminMenu() {
+        return adminMenu;
     }
 }

--- a/src/main/java/com/example/bedwars/arena/ArenaManager.java
+++ b/src/main/java/com/example/bedwars/arena/ArenaManager.java
@@ -1,7 +1,6 @@
 package com.example.bedwars.arena;
 
 import com.example.bedwars.BedwarsPlugin;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 
 import java.io.File;
@@ -9,6 +8,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.io.IOException;
+import org.bukkit.configuration.file.YamlConfiguration;
 
 /**
  * Loads arenas from the plugin's "arenas" folder and allows players
@@ -35,6 +36,51 @@ public class ArenaManager {
             String name = cfg.getString("name", file.getName().replace(".yml", ""));
             arenas.put(name.toLowerCase(), new Arena(plugin, name));
         }
+    }
+
+    /**
+     * Creates a new arena configuration and adds it to the manager.
+     * Only the arena name and world are persisted.
+     *
+     * @param id    arena identifier
+     * @param world target world name
+     * @return true if created, false if an arena with this id already exists
+     */
+    public boolean createArena(String id, String world) {
+        String key = id.toLowerCase();
+        if (arenas.containsKey(key)) {
+            return false;
+        }
+        File file = new File(plugin.getDataFolder(), "arenas/" + id + ".yml");
+        YamlConfiguration cfg = new YamlConfiguration();
+        cfg.set("name", id);
+        cfg.set("world", world);
+        try {
+            cfg.save(file);
+        } catch (IOException e) {
+            plugin.getLogger().warning("Could not save arena " + id + ": " + e.getMessage());
+        }
+        arenas.put(key, new Arena(plugin, id));
+        return true;
+    }
+
+    /**
+     * Deletes an arena and removes its configuration file.
+     *
+     * @param id arena identifier
+     * @return true if deleted, false otherwise
+     */
+    public boolean deleteArena(String id) {
+        String key = id.toLowerCase();
+        Arena arena = arenas.remove(key);
+        if (arena == null) {
+            return false;
+        }
+        File file = new File(plugin.getDataFolder(), "arenas/" + id + ".yml");
+        if (file.exists() && !file.delete()) {
+            plugin.getLogger().warning("Could not delete arena file " + file.getName());
+        }
+        return true;
     }
 
     public Map<String, Arena> getArenas() {

--- a/src/main/java/com/example/bedwars/command/AdminCommand.java
+++ b/src/main/java/com/example/bedwars/command/AdminCommand.java
@@ -1,0 +1,114 @@
+package com.example.bedwars.command;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Basic administrative command covering a tiny subset of the desired
+ * functionality. It currently supports creating, deleting and listing
+ * arenas to illustrate how the real command framework could be wired.
+ */
+public class AdminCommand implements CommandExecutor, TabCompleter {
+
+    private final BedwarsPlugin plugin;
+
+    public AdminCommand(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("bedwars.admin.arena")) {
+            sender.sendMessage(plugin.getMessages().get("error.not_admin"));
+            return true;
+        }
+
+        if (args.length == 0) {
+            sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin arena <create|delete|list>")));
+            return true;
+        }
+
+        if (!args[0].equalsIgnoreCase("arena")) {
+            sender.sendMessage(plugin.getMessages().get("command.unknown"));
+            return true;
+        }
+
+        if (args.length < 2) {
+            sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin arena <create|delete|list>")));
+            return true;
+        }
+
+        switch (args[1].toLowerCase()) {
+            case "list" -> {
+                String arenas = String.join(", ", plugin.getArenaManager().getArenas().keySet());
+                sender.sendMessage(plugin.getMessages().get("command.list", Map.of("arenas", arenas)));
+                return true;
+            }
+            case "create" -> {
+                if (args.length < 4) {
+                    sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin arena create <id> <world>")));
+                    return true;
+                }
+                World world = Bukkit.getWorld(args[3]);
+                if (world == null) {
+                    sender.sendMessage(plugin.getMessages().get("error.no_world", Map.of("world", args[3])));
+                    return true;
+                }
+                boolean created = plugin.getArenaManager().createArena(args[2], world.getName());
+                if (created) {
+                    sender.sendMessage(plugin.getMessages().get("arena.created", Map.of("arena", args[2])));
+                } else {
+                    sender.sendMessage(plugin.getMessages().get("arena.exists", Map.of("arena", args[2])));
+                }
+                return true;
+            }
+            case "delete" -> {
+                if (args.length < 3) {
+                    sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin arena delete <id>")));
+                    return true;
+                }
+                boolean deleted = plugin.getArenaManager().deleteArena(args[2]);
+                if (deleted) {
+                    sender.sendMessage(plugin.getMessages().get("arena.deleted", Map.of("arena", args[2])));
+                } else {
+                    sender.sendMessage(plugin.getMessages().get("error.no_arena"));
+                }
+                return true;
+            }
+            default -> {
+                sender.sendMessage(plugin.getMessages().get("command.unknown"));
+                return true;
+            }
+        }
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!sender.hasPermission("bedwars.admin.arena")) {
+            return Collections.emptyList();
+        }
+        if (args.length == 1) {
+            return Collections.singletonList("arena");
+        } else if (args.length == 2 && args[0].equalsIgnoreCase("arena")) {
+            return List.of("create", "delete", "list");
+        } else if (args.length == 3 && args[0].equalsIgnoreCase("arena")) {
+            if (args[1].equalsIgnoreCase("delete")) {
+                return new ArrayList<>(plugin.getArenaManager().getArenas().keySet());
+            }
+        } else if (args.length == 4 && args[0].equalsIgnoreCase("arena") && args[1].equalsIgnoreCase("create")) {
+            return Bukkit.getWorlds().stream().map(World::getName).collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/example/bedwars/command/BedwarsCommand.java
+++ b/src/main/java/com/example/bedwars/command/BedwarsCommand.java
@@ -36,6 +36,15 @@ public class BedwarsCommand implements CommandExecutor {
         }
 
         switch (args[0].toLowerCase()) {
+            case "menu":
+            case "admin":
+            case "setup":
+                if (!player.hasPermission("bedwars.admin")) {
+                    player.sendMessage(plugin.getMessages().get("error.not_admin"));
+                    return true;
+                }
+                plugin.getAdminMenu().open(player);
+                return true;
             case "list" -> {
                 String arenas = String.join(", ", plugin.getArenaManager().getArenas().keySet());
                 player.sendMessage(plugin.getMessages().get("command.list", Map.of("arenas", arenas)));

--- a/src/main/java/com/example/bedwars/gui/AdminMenu.java
+++ b/src/main/java/com/example/bedwars/gui/AdminMenu.java
@@ -1,0 +1,51 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Very lightweight management menu. It only displays a few placeholder
+ * items so administrators can open a GUI and navigate to future
+ * functionality. Real editing logic is intentionally omitted but the
+ * structure mirrors the spec so new features can hook into it later.
+ */
+public class AdminMenu {
+
+    private final BedwarsPlugin plugin;
+
+    public AdminMenu(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Opens the main management GUI for the given player.
+     *
+     * @param player the player to open the GUI for
+     */
+    public void open(Player player) {
+        Inventory inv = Bukkit.createInventory(null, 54, plugin.getMessages().get("admin.menu-title"));
+        inv.setItem(10, item(Material.MAP, plugin.getMessages().get("admin.menu.arenas")));
+        inv.setItem(12, item(Material.LIME_WOOL, plugin.getMessages().get("admin.menu.create")));
+        inv.setItem(14, item(Material.BOOK, plugin.getMessages().get("admin.menu.rules")));
+        inv.setItem(16, item(Material.ARMOR_STAND, plugin.getMessages().get("admin.menu.npc")));
+        inv.setItem(28, item(Material.REPEATER, plugin.getMessages().get("admin.menu.rotation")));
+        inv.setItem(30, item(Material.REDSTONE_COMPARATOR, plugin.getMessages().get("admin.menu.diagnostics")));
+        inv.setItem(32, item(Material.PAPER, plugin.getMessages().get("admin.menu.info")));
+        player.openInventory(inv);
+    }
+
+    private ItemStack item(Material mat, String name) {
+        ItemStack it = new ItemStack(mat);
+        ItemMeta meta = it.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            it.setItemMeta(meta);
+        }
+        return it;
+    }
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,6 +1,8 @@
 prefix: "&6[BedWars]&r "
 arena:
   created: "&aArène &e{arena}&a créée."
+  deleted: "&cArène &e{arena}&c supprimée."
+  exists: "&cL'arène &e{arena}&c existe déjà."
   saved: "&aArène &e{arena}&a sauvegardée."
   started: "&aLa partie &e{arena}&a commence !"
   stopped: "&cLa partie &e{arena}&c est arrêtée."
@@ -11,6 +13,7 @@ team:
 error:
   no_arena: "&cAucune arène avec ce nom."
   not_admin: "&cVous n'avez pas la permission."
+  no_world: "&cMonde introuvable: &e{world}"
   usage: "&eUtilisation: {usage}"
 shop:
   not_enough: "&cPas assez de ressources."
@@ -27,3 +30,13 @@ command:
   list: "&aArènes disponibles: &e{arenas}"
   join-usage: "&cUsage: /bw join <arène>"
   unknown: "&cSous-commande inconnue"
+admin:
+  menu-title: "&6Gestion BedWars"
+  menu:
+    arenas: "&eArènes"
+    create: "&aCréer une arène"
+    rules: "&bRègles de jeu"
+    npc: "&dHologrammes/PNJ"
+    rotation: "&dRotation & Reset"
+    diagnostics: "&cDiagnostics"
+    info: "&fRetour / Infos"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,9 +8,22 @@ commands:
   bw:
     description: Menu BedWars + commandes
     usage: /bw
+  bwadmin:
+    description: Commandes d'administration BedWars
+    usage: /bwadmin
+    permission: bedwars.admin.arena
 permissions:
+  bedwars.admin.*:
+    description: Toutes les permissions admin
+    default: op
+    children:
+      bedwars.admin: true
+      bedwars.admin.arena: true
   bedwars.admin:
-    description: Admin BedWars
+    description: Accès au menu de gestion
+    default: op
+  bedwars.admin.arena:
+    description: Gestion des arènes
     default: op
   bedwars.join:
     description: Rejoindre une arène


### PR DESCRIPTION
## Summary
- Add `/bw menu` subcommand to open a placeholder management GUI
- Introduce `/bwadmin` command with arena create/delete/list and tab completion
- Persist arena creation and deletion through `ArenaManager`
- Expand plugin.yml permissions and messages for admin features

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable for Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689b8c9e3a548329ac7789a64e17a0d2