### PR TITLE
Fix command switch and menu imports

### DIFF
--- a/src/main/java/com/example/bedwars/command/BedwarsCommand.java
+++ b/src/main/java/com/example/bedwars/command/BedwarsCommand.java
@@ -36,15 +36,14 @@ public class BedwarsCommand implements CommandExecutor {
         }
 
         switch (args[0].toLowerCase()) {
-            case "menu":
-            case "admin":
-            case "setup":
+            case "menu", "admin", "setup" -> {
                 if (!player.hasPermission("bedwars.admin")) {
                     player.sendMessage(plugin.getMessages().get("error.not_admin"));
                     return true;
                 }
                 plugin.getAdminMenu().open(player);
                 return true;
+            }
             case "list" -> {
                 String arenas = String.join(", ", plugin.getArenaManager().getArenas().keySet());
                 player.sendMessage(plugin.getMessages().get("command.list", Map.of("arenas", arenas)));

--- a/src/main/java/com/example/bedwars/gui/AdminMenu.java
+++ b/src/main/java/com/example/bedwars/gui/AdminMenu.java
@@ -2,6 +2,7 @@ package com.example.bedwars.gui;
 
 import com.example.bedwars.BedwarsPlugin;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -43,7 +44,7 @@ public class AdminMenu {
         ItemStack it = new ItemStack(mat);
         ItemMeta meta = it.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(name);
+            meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
             it.setItemMeta(meta);
         }
         return it;


### PR DESCRIPTION
## Summary
- ensure Admin menu items use ChatColor and proper imports
- switch command handler to arrow-style labels for all subcommands

## Testing
- `MAVEN_OPTS="-Djava.net.preferIPv4Stack=true" mvn -q -DskipTests package` (fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1, Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_689b8fd2cd9483298a02e7b35594b62d