### PR TITLE
feat: add basic game events toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.2.2
+- Ajout d'une commande `/bwadmin game events <arène> <enable|disable>` pour activer ou désactiver les événements de partie.
+- Ajout d'une entrée "Événements" dans le menu d'administration.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ une réécriture complète.
 ## Mise en route rapide
 
 1. Compiler le plugin : `mvn -DskipTests package`.
-2. Copier `target/bedwars-0.2.0.jar` dans le dossier `plugins/` du serveur.
+2. Copier `target/bedwars-0.2.2.jar` dans le dossier `plugins/` du serveur.
 3. Démarrer le serveur et utiliser `/bw list` pour voir les arènes disponibles.
 4. Rejoindre une arène avec `/bw join <nom>` puis quitter avec `/bw leave`.
 
@@ -28,6 +28,7 @@ permission `bedwars.admin`.
 * `/bwadmin arena list` : liste les arènes chargées.
 * `/bwadmin arena create <id> <monde>` : crée une arène minimale.
 * `/bwadmin arena delete <id>` : supprime une arène et son fichier.
+* `/bwadmin game events <arène> <enable|disable>` : active ou désactive les événements de partie.
 
 Ces commandes ne couvrent qu'une petite partie du framework souhaité mais
 servent de point de départ pour l'étendre.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>com.example</groupId>
 <artifactId>bedwars</artifactId>
-<version>0.2.0</version>
+<version>0.2.2</version>
 <name>Bedwars</name>
 <description>BedWars FR with GUI for Spigot/Paper 1.21</description>
 <properties>

--- a/src/main/java/com/example/bedwars/arena/Arena.java
+++ b/src/main/java/com/example/bedwars/arena/Arena.java
@@ -23,6 +23,7 @@ public class Arena {
     private final BedwarsPlugin plugin;
     private GameState state = GameState.WAITING;
     private int countdown = 10; // seconds
+    private boolean eventsEnabled = true;
 
     public Arena(BedwarsPlugin plugin, String name) {
         this.plugin = plugin;
@@ -35,6 +36,14 @@ public class Arena {
 
     public GameState getState() {
         return state;
+    }
+
+    public boolean isEventsEnabled() {
+        return eventsEnabled;
+    }
+
+    public void setEventsEnabled(boolean eventsEnabled) {
+        this.eventsEnabled = eventsEnabled;
     }
 
     public void addPlayer(Player player) {
@@ -73,6 +82,7 @@ public class Arena {
     private void reset() {
         state = GameState.WAITING;
         countdown = 10;
+        eventsEnabled = true;
     }
 
     private void broadcast(String msg) {

--- a/src/main/java/com/example/bedwars/command/AdminCommand.java
+++ b/src/main/java/com/example/bedwars/command/AdminCommand.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 /**
  * Basic administrative command covering a tiny subset of the desired
  * functionality. It currently supports creating, deleting and listing
- * arenas to illustrate how the real command framework could be wired.
+ * arenas as well as enabling or disabling the simplified event timeline.
  */
 public class AdminCommand implements CommandExecutor, TabCompleter {
 
@@ -29,62 +29,88 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (!sender.hasPermission("bedwars.admin.arena")) {
+        if (!sender.hasPermission("bedwars.admin")) {
             sender.sendMessage(plugin.getMessages().get("error.not_admin"));
             return true;
         }
 
         if (args.length == 0) {
-            sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin arena <create|delete|list>")));
+            sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin <arena|game> ...")));
             return true;
         }
 
-        if (!args[0].equalsIgnoreCase("arena")) {
-            sender.sendMessage(plugin.getMessages().get("command.unknown"));
-            return true;
-        }
-
-        if (args.length < 2) {
-            sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin arena <create|delete|list>")));
-            return true;
-        }
-
-        switch (args[1].toLowerCase()) {
-            case "list" -> {
-                String arenas = String.join(", ", plugin.getArenaManager().getArenas().keySet());
-                sender.sendMessage(plugin.getMessages().get("command.list", Map.of("arenas", arenas)));
-                return true;
+        switch (args[0].toLowerCase()) {
+            case "arena" -> {
+                if (!sender.hasPermission("bedwars.admin.arena")) {
+                    sender.sendMessage(plugin.getMessages().get("error.not_admin"));
+                    return true;
+                }
+                if (args.length < 2) {
+                    sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin arena <create|delete|list>")));
+                    return true;
+                }
+                switch (args[1].toLowerCase()) {
+                    case "list" -> {
+                        String arenas = String.join(", ", plugin.getArenaManager().getArenas().keySet());
+                        sender.sendMessage(plugin.getMessages().get("command.list", Map.of("arenas", arenas)));
+                        return true;
+                    }
+                    case "create" -> {
+                        if (args.length < 4) {
+                            sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin arena create <id> <world>")));
+                            return true;
+                        }
+                        World world = Bukkit.getWorld(args[3]);
+                        if (world == null) {
+                            sender.sendMessage(plugin.getMessages().get("error.no_world", Map.of("world", args[3])));
+                            return true;
+                        }
+                        boolean created = plugin.getArenaManager().createArena(args[2], world.getName());
+                        if (created) {
+                            sender.sendMessage(plugin.getMessages().get("arena.created", Map.of("arena", args[2])));
+                        } else {
+                            sender.sendMessage(plugin.getMessages().get("arena.exists", Map.of("arena", args[2])));
+                        }
+                        return true;
+                    }
+                    case "delete" -> {
+                        if (args.length < 3) {
+                            sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin arena delete <id>")));
+                            return true;
+                        }
+                        boolean deleted = plugin.getArenaManager().deleteArena(args[2]);
+                        if (deleted) {
+                            sender.sendMessage(plugin.getMessages().get("arena.deleted", Map.of("arena", args[2])));
+                        } else {
+                            sender.sendMessage(plugin.getMessages().get("error.no_arena"));
+                        }
+                        return true;
+                    }
+                    default -> {
+                        sender.sendMessage(plugin.getMessages().get("command.unknown"));
+                        return true;
+                    }
+                }
             }
-            case "create" -> {
-                if (args.length < 4) {
-                    sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin arena create <id> <world>")));
+            case "game" -> {
+                if (!sender.hasPermission("bedwars.admin.game")) {
+                    sender.sendMessage(plugin.getMessages().get("error.not_admin"));
                     return true;
                 }
-                World world = Bukkit.getWorld(args[3]);
-                if (world == null) {
-                    sender.sendMessage(plugin.getMessages().get("error.no_world", Map.of("world", args[3])));
+                if (args.length < 4 || !args[1].equalsIgnoreCase("events")) {
+                    sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin game events <arena> <enable|disable>")));
                     return true;
                 }
-                boolean created = plugin.getArenaManager().createArena(args[2], world.getName());
-                if (created) {
-                    sender.sendMessage(plugin.getMessages().get("arena.created", Map.of("arena", args[2])));
-                } else {
-                    sender.sendMessage(plugin.getMessages().get("arena.exists", Map.of("arena", args[2])));
-                }
-                return true;
-            }
-            case "delete" -> {
-                if (args.length < 3) {
-                    sender.sendMessage(plugin.getMessages().get("error.usage", Map.of("usage", "/bwadmin arena delete <id>")));
+                return plugin.getArenaManager().getArena(args[2]).map(arena -> {
+                    boolean enable = args[3].equalsIgnoreCase("enable");
+                    arena.setEventsEnabled(enable);
+                    String key = enable ? "arena.events_enabled" : "arena.events_disabled";
+                    sender.sendMessage(plugin.getMessages().get(key, Map.of("arena", arena.getName())));
                     return true;
-                }
-                boolean deleted = plugin.getArenaManager().deleteArena(args[2]);
-                if (deleted) {
-                    sender.sendMessage(plugin.getMessages().get("arena.deleted", Map.of("arena", args[2])));
-                } else {
+                }).orElseGet(() -> {
                     sender.sendMessage(plugin.getMessages().get("error.no_arena"));
-                }
-                return true;
+                    return true;
+                });
             }
             default -> {
                 sender.sendMessage(plugin.getMessages().get("command.unknown"));
@@ -95,20 +121,31 @@ public class AdminCommand implements CommandExecutor, TabCompleter {
 
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
-        if (!sender.hasPermission("bedwars.admin.arena")) {
+        if (!sender.hasPermission("bedwars.admin")) {
             return Collections.emptyList();
         }
         if (args.length == 1) {
-            return Collections.singletonList("arena");
-        } else if (args.length == 2 && args[0].equalsIgnoreCase("arena")) {
-            return List.of("create", "delete", "list");
-        } else if (args.length == 3 && args[0].equalsIgnoreCase("arena")) {
-            if (args[1].equalsIgnoreCase("delete")) {
+            return List.of("arena", "game");
+        } else if (args.length == 2) {
+            if (args[0].equalsIgnoreCase("arena")) {
+                return List.of("create", "delete", "list");
+            } else if (args[0].equalsIgnoreCase("game")) {
+                return List.of("events");
+            }
+        } else if (args.length == 3) {
+            if (args[0].equalsIgnoreCase("arena") && args[1].equalsIgnoreCase("delete")) {
+                return new ArrayList<>(plugin.getArenaManager().getArenas().keySet());
+            } else if (args[0].equalsIgnoreCase("game") && args[1].equalsIgnoreCase("events")) {
                 return new ArrayList<>(plugin.getArenaManager().getArenas().keySet());
             }
-        } else if (args.length == 4 && args[0].equalsIgnoreCase("arena") && args[1].equalsIgnoreCase("create")) {
-            return Bukkit.getWorlds().stream().map(World::getName).collect(Collectors.toList());
+        } else if (args.length == 4) {
+            if (args[0].equalsIgnoreCase("arena") && args[1].equalsIgnoreCase("create")) {
+                return Bukkit.getWorlds().stream().map(World::getName).collect(Collectors.toList());
+            } else if (args[0].equalsIgnoreCase("game") && args[1].equalsIgnoreCase("events")) {
+                return List.of("enable", "disable");
+            }
         }
         return Collections.emptyList();
     }
 }
+

--- a/src/main/java/com/example/bedwars/gui/AdminMenu.java
+++ b/src/main/java/com/example/bedwars/gui/AdminMenu.java
@@ -40,6 +40,7 @@ public class AdminMenu {
         inv.setItem(28, item(Material.ENDER_PEARL, plugin.getMessages().get("admin.menu.rotation")));
         inv.setItem(30, item(Material.REDSTONE_COMPARATOR, plugin.getMessages().get("admin.menu.diagnostics")));
         inv.setItem(32, item(Material.PAPER, plugin.getMessages().get("admin.menu.info")));
+        inv.setItem(34, item(Material.CLOCK, plugin.getMessages().get("admin.menu.events")));
         player.openInventory(inv);
     }
 

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -8,6 +8,8 @@ arena:
   stopped: "&cLa partie &e{arena}&c est arrêtée."
   join: "&aVous avez rejoint &e{arena}&a."
   leave: "&eVous avez quitté l'arène."
+  events_enabled: "&aÉvénements activés pour &e{arena}&a."
+  events_disabled: "&cÉvénements désactivés pour &e{arena}&c."
 team:
   bed_destroyed: "&cLe lit de l'équipe &e{team}&c a été détruit par &e{player}&c !"
 error:
@@ -35,6 +37,7 @@ admin:
   menu:
     arenas: "&eArènes"
     create: "&aCréer une arène"
+    events: "&bÉvénements"
     rules: "&bRègles de jeu"
     npc: "&dHologrammes/PNJ"
     rotation: "&dRotation & Reset"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: Bedwars
 main: com.example.bedwars.BedwarsPlugin
-version: 0.2.1
+version: 0.2.2
 api-version: '1.21'
 author: You
 description: BedWars FR GUI (non-affilié Hypixel)
@@ -12,7 +12,7 @@ commands:
   bwadmin:
     description: Commandes d'administration BedWars
     usage: /bwadmin
-    permission: bedwars.admin.arena
+    permission: bedwars.admin
 permissions:
   bedwars.admin.*:
     description: Toutes les permissions admin
@@ -20,11 +20,15 @@ permissions:
     children:
       bedwars.admin: true
       bedwars.admin.arena: true
+      bedwars.admin.game: true
   bedwars.admin:
     description: Accès au menu de gestion
     default: op
   bedwars.admin.arena:
     description: Gestion des arènes
+    default: op
+  bedwars.admin.game:
+    description: Gestion des événements de jeu
     default: op
   bedwars.join:
     description: Rejoindre une arène


### PR DESCRIPTION
## Summary
- allow arenas to enable or disable a simple event timeline
- add `/bwadmin game events <arena> <enable|disable>` command with tab completion
- expose an "Événements" placeholder in the admin GUI

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b99a8a9b883299803187e1551cf50