### PR TITLE
feat: add basic admin menu manager

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -3,7 +3,8 @@ package com.example.bedwars;
 import com.example.bedwars.arena.ArenaManager;
 import com.example.bedwars.command.AdminCommand;
 import com.example.bedwars.command.BedwarsCommand;
-import com.example.bedwars.gui.AdminMenu;
+import com.example.bedwars.gui.MenuManager;
+import com.example.bedwars.gui.*;
 import com.example.bedwars.listener.PlayerListener;
 import com.example.bedwars.util.MessageManager;
 import org.bukkit.NamespacedKey;
@@ -19,7 +20,7 @@ public class BedwarsPlugin extends JavaPlugin {
 
     private ArenaManager arenaManager;
     private MessageManager messageManager;
-    private AdminMenu adminMenu;
+    private MenuManager menuManager;
     private NamespacedKey arenaKey;
 
     @Override
@@ -27,7 +28,18 @@ public class BedwarsPlugin extends JavaPlugin {
         saveDefaultConfig();
         this.messageManager = new MessageManager(this);
         this.arenaManager = new ArenaManager(this);
-        this.adminMenu = new AdminMenu(this);
+        this.menuManager = new MenuManager(this);
+        // Register menus
+        menuManager.register(new RootMenu(this));
+        menuManager.register(new ArenasMenu(this));
+        menuManager.register(new ArenaEditorMenu(this));
+        menuManager.register(new RulesEventsMenu(this));
+        menuManager.register(new NpcShopsMenu(this));
+        menuManager.register(new GeneratorsMenu(this));
+        menuManager.register(new RotationMenu(this));
+        menuManager.register(new ResetMenu(this));
+        menuManager.register(new DiagnosticsMenu(this));
+
         this.arenaKey = new NamespacedKey(this, "bw_arena");
 
         // Register command executors
@@ -38,6 +50,7 @@ public class BedwarsPlugin extends JavaPlugin {
 
         // Register basic listeners
         getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
+        getServer().getPluginManager().registerEvents(menuManager, this);
     }
 
     public ArenaManager getArenaManager() {
@@ -48,8 +61,8 @@ public class BedwarsPlugin extends JavaPlugin {
         return messageManager;
     }
 
-    public AdminMenu getAdminMenu() {
-        return adminMenu;
+    public MenuManager getMenuManager() {
+        return menuManager;
     }
 
     /**

--- a/src/main/java/com/example/bedwars/command/BedwarsCommand.java
+++ b/src/main/java/com/example/bedwars/command/BedwarsCommand.java
@@ -41,7 +41,7 @@ public class BedwarsCommand implements CommandExecutor {
                     player.sendMessage(plugin.getMessages().get("error.not_admin"));
                     return true;
                 }
-                plugin.getAdminMenu().open(player);
+                  plugin.getMenuManager().openRoot(player);
                 return true;
             }
             case "list" -> {

--- a/src/main/java/com/example/bedwars/gui/AdminView.java
+++ b/src/main/java/com/example/bedwars/gui/AdminView.java
@@ -1,0 +1,16 @@
+package com.example.bedwars.gui;
+
+/**
+ * Enumeration of all administrative menu views.
+ */
+public enum AdminView {
+    ROOT,
+    ARENAS,
+    ARENA_EDITOR,
+    RULES_EVENTS,
+    NPC_SHOPS,
+    GENERATORS,
+    ROTATION,
+    RESET,
+    DIAGNOSTICS
+}

--- a/src/main/java/com/example/bedwars/gui/ArenaEditorMenu.java
+++ b/src/main/java/com/example/bedwars/gui/ArenaEditorMenu.java
@@ -1,0 +1,43 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class ArenaEditorMenu implements BWMenu {
+
+    private final BedwarsPlugin plugin;
+
+    public ArenaEditorMenu(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public AdminView id() {
+        return AdminView.ARENA_EDITOR;
+    }
+
+    @Override
+    public void open(Player player, Object... args) {
+        String arena = args.length > 0 ? String.valueOf(args[0]) : "?";
+        String title = ChatColor.translateAlternateColorCodes('&', "&6Édition " + arena);
+        Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.ARENA_EDITOR, arena), 27, title);
+        inv.setItem(26, backItem());
+        player.openInventory(inv);
+    }
+
+    private ItemStack backItem() {
+        ItemStack it = new ItemStack(Material.BARRIER);
+        ItemMeta meta = it.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Retour");
+            it.setItemMeta(meta);
+        }
+        return it;
+    }
+}

--- a/src/main/java/com/example/bedwars/gui/ArenasMenu.java
+++ b/src/main/java/com/example/bedwars/gui/ArenasMenu.java
@@ -1,0 +1,60 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class ArenasMenu implements BWMenu {
+
+    private final BedwarsPlugin plugin;
+
+    public ArenasMenu(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public AdminView id() {
+        return AdminView.ARENAS;
+    }
+
+    @Override
+    public void open(Player player, Object... args) {
+        String title = ChatColor.translateAlternateColorCodes('&',
+                String.valueOf(plugin.getMessages().get("admin.menu.arenas")));
+        Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.ARENAS, null), 54, title);
+        int slot = 0;
+        for (String arenaId : plugin.getArenaManager().getArenas().keySet()) {
+            if (slot >= 53) {
+                break;
+            }
+            inv.setItem(slot++, arenaItem(arenaId));
+        }
+        inv.setItem(53, backItem());
+        player.openInventory(inv);
+    }
+
+    private ItemStack arenaItem(String id) {
+        ItemStack map = new ItemStack(Material.MAP);
+        ItemMeta meta = map.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(id);
+            map.setItemMeta(meta);
+        }
+        return map;
+    }
+
+    private ItemStack backItem() {
+        ItemStack it = new ItemStack(Material.BARRIER);
+        ItemMeta meta = it.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Retour");
+            it.setItemMeta(meta);
+        }
+        return it;
+    }
+}

--- a/src/main/java/com/example/bedwars/gui/BWMenu.java
+++ b/src/main/java/com/example/bedwars/gui/BWMenu.java
@@ -1,0 +1,21 @@
+package com.example.bedwars.gui;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Basic API for plugin menus.
+ */
+public interface BWMenu {
+    /**
+     * @return the view identifier of this menu
+     */
+    AdminView id();
+
+    /**
+     * Opens the menu for the given player.
+     *
+     * @param player the target player
+     * @param args optional extra context
+     */
+    void open(Player player, Object... args);
+}

--- a/src/main/java/com/example/bedwars/gui/BWMenuHolder.java
+++ b/src/main/java/com/example/bedwars/gui/BWMenuHolder.java
@@ -1,0 +1,31 @@
+package com.example.bedwars.gui;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+/**
+ * Holder storing the current admin view and optional arena context.
+ */
+public class BWMenuHolder implements InventoryHolder {
+
+    private final AdminView view;
+    private final String arenaId;
+
+    public BWMenuHolder(AdminView view, String arenaId) {
+        this.view = view;
+        this.arenaId = arenaId;
+    }
+
+    public AdminView getView() {
+        return view;
+    }
+
+    public String getArenaId() {
+        return arenaId;
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return null; // Not used
+    }
+}

--- a/src/main/java/com/example/bedwars/gui/DiagnosticsMenu.java
+++ b/src/main/java/com/example/bedwars/gui/DiagnosticsMenu.java
@@ -1,0 +1,42 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class DiagnosticsMenu implements BWMenu {
+
+    private final BedwarsPlugin plugin;
+
+    public DiagnosticsMenu(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public AdminView id() {
+        return AdminView.DIAGNOSTICS;
+    }
+
+    @Override
+    public void open(Player player, Object... args) {
+        String title = ChatColor.translateAlternateColorCodes('&', "&6Diagnostics");
+        Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.DIAGNOSTICS, null), 27, title);
+        inv.setItem(26, backItem());
+        player.openInventory(inv);
+    }
+
+    private ItemStack backItem() {
+        ItemStack it = new ItemStack(Material.BARRIER);
+        ItemMeta meta = it.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Retour");
+            it.setItemMeta(meta);
+        }
+        return it;
+    }
+}

--- a/src/main/java/com/example/bedwars/gui/GeneratorsMenu.java
+++ b/src/main/java/com/example/bedwars/gui/GeneratorsMenu.java
@@ -1,0 +1,42 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class GeneratorsMenu implements BWMenu {
+
+    private final BedwarsPlugin plugin;
+
+    public GeneratorsMenu(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public AdminView id() {
+        return AdminView.GENERATORS;
+    }
+
+    @Override
+    public void open(Player player, Object... args) {
+        String title = ChatColor.translateAlternateColorCodes('&', "&6Générateurs");
+        Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.GENERATORS, null), 27, title);
+        inv.setItem(26, backItem());
+        player.openInventory(inv);
+    }
+
+    private ItemStack backItem() {
+        ItemStack it = new ItemStack(Material.BARRIER);
+        ItemMeta meta = it.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Retour");
+            it.setItemMeta(meta);
+        }
+        return it;
+    }
+}

--- a/src/main/java/com/example/bedwars/gui/MenuManager.java
+++ b/src/main/java/com/example/bedwars/gui/MenuManager.java
@@ -1,0 +1,112 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Central registry for admin menus with basic click routing.
+ */
+public class MenuManager implements Listener {
+
+    private final BedwarsPlugin plugin;
+    private final Map<AdminView, BWMenu> menus = new EnumMap<>(AdminView.class);
+    private final Map<UUID, String> arenaContext = new HashMap<>();
+
+    public MenuManager(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void register(BWMenu menu) {
+        menus.put(menu.id(), menu);
+    }
+
+    public void open(Player player, AdminView view, String arenaId, Object... args) {
+        if (arenaId != null) {
+            arenaContext.put(player.getUniqueId(), arenaId);
+        } else {
+            arenaContext.remove(player.getUniqueId());
+        }
+        BWMenu menu = menus.get(view);
+        if (menu != null) {
+            menu.open(player, args);
+        }
+    }
+
+    public void openRoot(Player player) {
+        open(player, AdminView.ROOT, null);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (event.getClickedInventory() == null) {
+            return;
+        }
+        if (event.getView().getTopInventory().getHolder() instanceof BWMenuHolder holder) {
+            event.setCancelled(true);
+            AdminView view = holder.getView();
+            int slot = event.getRawSlot();
+            switch (view) {
+                case ROOT -> handleRootClick(player, slot);
+                case ARENAS -> handleArenasClick(player, slot);
+                case ARENA_EDITOR -> handleArenaEditorClick(player, slot);
+                case RULES_EVENTS, NPC_SHOPS, GENERATORS, ROTATION, RESET, DIAGNOSTICS -> {
+                    if (slot == 26) {
+                        openRoot(player);
+                    }
+                }
+                default -> {
+                }
+            }
+        }
+    }
+
+    private void handleRootClick(Player player, int slot) {
+        switch (slot) {
+            case 10 -> open(player, AdminView.ARENAS, null);
+            case 12 -> player.closeInventory(); // placeholder for arena creation
+            case 14 -> open(player, AdminView.RULES_EVENTS, null);
+            case 16 -> open(player, AdminView.NPC_SHOPS, null);
+            case 28 -> open(player, AdminView.ROTATION, null);
+            case 30 -> open(player, AdminView.RESET, null);
+            case 32 -> open(player, AdminView.DIAGNOSTICS, null);
+            default -> {
+            }
+        }
+    }
+
+    private void handleArenasClick(Player player, int slot) {
+        if (slot == 53) {
+            openRoot(player);
+            return;
+        }
+        var inv = player.getOpenInventory().getTopInventory();
+        var item = inv.getItem(slot);
+        if (item != null && item.hasItemMeta()) {
+            String arena = item.getItemMeta().getDisplayName();
+            open(player, AdminView.ARENA_EDITOR, arena, arena);
+        }
+    }
+
+    private void handleArenaEditorClick(Player player, int slot) {
+        if (slot == 26) {
+            open(player, AdminView.ARENAS, null);
+        }
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        // nothing for now
+    }
+}

--- a/src/main/java/com/example/bedwars/gui/NpcShopsMenu.java
+++ b/src/main/java/com/example/bedwars/gui/NpcShopsMenu.java
@@ -1,0 +1,42 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class NpcShopsMenu implements BWMenu {
+
+    private final BedwarsPlugin plugin;
+
+    public NpcShopsMenu(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public AdminView id() {
+        return AdminView.NPC_SHOPS;
+    }
+
+    @Override
+    public void open(Player player, Object... args) {
+        String title = ChatColor.translateAlternateColorCodes('&', "&6PNJ & Boutiques");
+        Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.NPC_SHOPS, null), 27, title);
+        inv.setItem(26, backItem());
+        player.openInventory(inv);
+    }
+
+    private ItemStack backItem() {
+        ItemStack it = new ItemStack(Material.BARRIER);
+        ItemMeta meta = it.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Retour");
+            it.setItemMeta(meta);
+        }
+        return it;
+    }
+}

--- a/src/main/java/com/example/bedwars/gui/ResetMenu.java
+++ b/src/main/java/com/example/bedwars/gui/ResetMenu.java
@@ -1,0 +1,42 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class ResetMenu implements BWMenu {
+
+    private final BedwarsPlugin plugin;
+
+    public ResetMenu(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public AdminView id() {
+        return AdminView.RESET;
+    }
+
+    @Override
+    public void open(Player player, Object... args) {
+        String title = ChatColor.translateAlternateColorCodes('&', "&6Reset");
+        Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.RESET, null), 27, title);
+        inv.setItem(26, backItem());
+        player.openInventory(inv);
+    }
+
+    private ItemStack backItem() {
+        ItemStack it = new ItemStack(Material.BARRIER);
+        ItemMeta meta = it.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Retour");
+            it.setItemMeta(meta);
+        }
+        return it;
+    }
+}

--- a/src/main/java/com/example/bedwars/gui/RootMenu.java
+++ b/src/main/java/com/example/bedwars/gui/RootMenu.java
@@ -10,29 +10,26 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 /**
- * Very lightweight management menu. It only displays a few placeholder
- * items so administrators can open a GUI and navigate to future
- * functionality. Real editing logic is intentionally omitted but the
- * structure mirrors the spec so new features can hook into it later.
+ * Main administration menu. Provides navigation to other views.
  */
-public class AdminMenu {
+public class RootMenu implements BWMenu {
 
     private final BedwarsPlugin plugin;
 
-    public AdminMenu(BedwarsPlugin plugin) {
+    public RootMenu(BedwarsPlugin plugin) {
         this.plugin = plugin;
     }
 
-    /**
-     * Opens the main management GUI for the given player.
-     *
-     * @param player the player to open the GUI for
-     */
-    public void open(Player player) {
-        String title = String.valueOf(plugin.getMessages().get("admin.menu-title"));
-        title = ChatColor.translateAlternateColorCodes('&', title);
+    @Override
+    public AdminView id() {
+        return AdminView.ROOT;
+    }
 
-        Inventory inv = Bukkit.createInventory(player, 54, title);
+    @Override
+    public void open(Player player, Object... args) {
+        String title = ChatColor.translateAlternateColorCodes('&',
+                String.valueOf(plugin.getMessages().get("admin.menu-title")));
+        Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.ROOT, null), 54, title);
         inv.setItem(10, item(Material.MAP, plugin.getMessages().get("admin.menu.arenas")));
         inv.setItem(12, item(Material.LIME_WOOL, plugin.getMessages().get("admin.menu.create")));
         inv.setItem(14, item(Material.ANVIL, plugin.getMessages().get("admin.menu.rules")));
@@ -40,11 +37,10 @@ public class AdminMenu {
         inv.setItem(28, item(Material.ENDER_PEARL, plugin.getMessages().get("admin.menu.rotation")));
         inv.setItem(30, item(Material.COMPARATOR, plugin.getMessages().get("admin.menu.diagnostics")));
         inv.setItem(32, item(Material.PAPER, plugin.getMessages().get("admin.menu.info")));
-        inv.setItem(34, item(Material.CLOCK, plugin.getMessages().get("admin.menu.events")));
         player.openInventory(inv);
     }
 
-    private ItemStack item(Material mat, String name) {
+    private ItemStack item(Material mat, Object name) {
         ItemStack it = new ItemStack(mat);
         ItemMeta meta = it.getItemMeta();
         if (meta != null) {

--- a/src/main/java/com/example/bedwars/gui/RotationMenu.java
+++ b/src/main/java/com/example/bedwars/gui/RotationMenu.java
@@ -1,0 +1,42 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class RotationMenu implements BWMenu {
+
+    private final BedwarsPlugin plugin;
+
+    public RotationMenu(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public AdminView id() {
+        return AdminView.ROTATION;
+    }
+
+    @Override
+    public void open(Player player, Object... args) {
+        String title = ChatColor.translateAlternateColorCodes('&', "&6Rotation");
+        Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.ROTATION, null), 27, title);
+        inv.setItem(26, backItem());
+        player.openInventory(inv);
+    }
+
+    private ItemStack backItem() {
+        ItemStack it = new ItemStack(Material.BARRIER);
+        ItemMeta meta = it.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Retour");
+            it.setItemMeta(meta);
+        }
+        return it;
+    }
+}

--- a/src/main/java/com/example/bedwars/gui/RulesEventsMenu.java
+++ b/src/main/java/com/example/bedwars/gui/RulesEventsMenu.java
@@ -1,0 +1,42 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public class RulesEventsMenu implements BWMenu {
+
+    private final BedwarsPlugin plugin;
+
+    public RulesEventsMenu(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public AdminView id() {
+        return AdminView.RULES_EVENTS;
+    }
+
+    @Override
+    public void open(Player player, Object... args) {
+        String title = ChatColor.translateAlternateColorCodes('&', "&6Règles & Événements");
+        Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.RULES_EVENTS, null), 27, title);
+        inv.setItem(26, backItem());
+        player.openInventory(inv);
+    }
+
+    private ItemStack backItem() {
+        ItemStack it = new ItemStack(Material.BARRIER);
+        ItemMeta meta = it.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RED + "Retour");
+            it.setItemMeta(meta);
+        }
+        return it;
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold menu API with `AdminView`, `BWMenu`, and `BWMenuHolder`
- add `MenuManager` listener to route clicks and open placeholder sub-menus
- integrate new menu system with root command

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ba121c5c0832989538932ec43f8f5