### PR TITLE
fix: correct admin diagnostics/reset labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.3
+- Correction des libellés "Diagnostics" et "Reset" dans le menu d'administration.
+- Harmonisation des titres et textes via `messages.yml`.
+
 ## 0.2.2
 - Ajout d'une commande `/bwadmin game events <arène> <enable|disable>` pour activer ou désactiver les événements de partie.
 - Ajout d'une entrée "Événements" dans le menu d'administration.

--- a/src/main/java/com/example/bedwars/gui/DiagnosticsMenu.java
+++ b/src/main/java/com/example/bedwars/gui/DiagnosticsMenu.java
@@ -24,18 +24,22 @@ public class DiagnosticsMenu implements BWMenu {
 
     @Override
     public void open(Player player, Object... args) {
-        String title = ChatColor.translateAlternateColorCodes('&', "&6Diagnostics");
+        String title = ChatColor.translateAlternateColorCodes('&',
+                String.valueOf(plugin.getMessages().get("admin.diagnostics-title")));
         Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.DIAGNOSTICS, null), 27, title);
-        inv.setItem(26, backItem());
+        inv.setItem(26, icon(Material.BARRIER, plugin.getMessages().get("admin.menu.info"),
+                plugin.getMessages().get("admin.menu.info-lore")));
         player.openInventory(inv);
     }
 
-    private ItemStack backItem() {
-        ItemStack it = new ItemStack(Material.BARRIER);
-        ItemMeta meta = it.getItemMeta();
-        if (meta != null) {
-            meta.setDisplayName(ChatColor.RED + "Retour");
-            it.setItemMeta(meta);
+    private ItemStack icon(Material mat, String name, String lore) {
+        ItemStack it = new ItemStack(mat);
+        ItemMeta im = it.getItemMeta();
+        if (im != null) {
+            im.setDisplayName(ChatColor.translateAlternateColorCodes('&', String.valueOf(name)));
+            if (lore != null && !lore.isEmpty())
+                im.setLore(java.util.List.of(ChatColor.translateAlternateColorCodes('&', lore)));
+            it.setItemMeta(im);
         }
         return it;
     }

--- a/src/main/java/com/example/bedwars/gui/ResetMenu.java
+++ b/src/main/java/com/example/bedwars/gui/ResetMenu.java
@@ -24,18 +24,22 @@ public class ResetMenu implements BWMenu {
 
     @Override
     public void open(Player player, Object... args) {
-        String title = ChatColor.translateAlternateColorCodes('&', "&6Reset");
+        String title = ChatColor.translateAlternateColorCodes('&',
+                String.valueOf(plugin.getMessages().get("admin.reset-title")));
         Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.RESET, null), 27, title);
-        inv.setItem(26, backItem());
+        inv.setItem(26, icon(Material.BARRIER, plugin.getMessages().get("admin.menu.info"),
+                plugin.getMessages().get("admin.menu.info-lore")));
         player.openInventory(inv);
     }
 
-    private ItemStack backItem() {
-        ItemStack it = new ItemStack(Material.BARRIER);
-        ItemMeta meta = it.getItemMeta();
-        if (meta != null) {
-            meta.setDisplayName(ChatColor.RED + "Retour");
-            it.setItemMeta(meta);
+    private ItemStack icon(Material mat, String name, String lore) {
+        ItemStack it = new ItemStack(mat);
+        ItemMeta im = it.getItemMeta();
+        if (im != null) {
+            im.setDisplayName(ChatColor.translateAlternateColorCodes('&', String.valueOf(name)));
+            if (lore != null && !lore.isEmpty())
+                im.setLore(java.util.List.of(ChatColor.translateAlternateColorCodes('&', lore)));
+            it.setItemMeta(im);
         }
         return it;
     }

--- a/src/main/java/com/example/bedwars/gui/RootMenu.java
+++ b/src/main/java/com/example/bedwars/gui/RootMenu.java
@@ -30,23 +30,25 @@ public class RootMenu implements BWMenu {
         String title = ChatColor.translateAlternateColorCodes('&',
                 String.valueOf(plugin.getMessages().get("admin.menu-title")));
         Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.ROOT, null), 54, title);
-        inv.setItem(10, item(Material.MAP, plugin.getMessages().get("admin.menu.arenas")));
-        inv.setItem(12, item(Material.LIME_WOOL, plugin.getMessages().get("admin.menu.create")));
-        inv.setItem(14, item(Material.ANVIL, plugin.getMessages().get("admin.menu.rules")));
-        inv.setItem(16, item(Material.ARMOR_STAND, plugin.getMessages().get("admin.menu.npc")));
-        inv.setItem(28, item(Material.ENDER_PEARL, plugin.getMessages().get("admin.menu.rotation")));
-        inv.setItem(30, item(Material.COMPARATOR, plugin.getMessages().get("admin.menu.diagnostics")));
-        inv.setItem(32, item(Material.PAPER, plugin.getMessages().get("admin.menu.info")));
+        inv.setItem(10, icon(Material.MAP, plugin.getMessages().get("admin.menu.arenas"), null));
+        inv.setItem(12, icon(Material.LIME_WOOL, plugin.getMessages().get("admin.menu.create"), null));
+        inv.setItem(14, icon(Material.ANVIL, plugin.getMessages().get("admin.menu.rules"), null));
+        inv.setItem(16, icon(Material.ARMOR_STAND, plugin.getMessages().get("admin.menu.npc"), null));
+        inv.setItem(28, icon(Material.ENDER_PEARL, plugin.getMessages().get("admin.menu.rotation"), null));
+        inv.setItem(30, icon(Material.TNT, plugin.getMessages().get("admin.menu.reset"), plugin.getMessages().get("admin.menu.reset-lore")));
+        inv.setItem(32, icon(Material.COMPARATOR, plugin.getMessages().get("admin.menu.diagnostics"), plugin.getMessages().get("admin.menu.diagnostics-lore")));
+        inv.setItem(34, icon(Material.PAPER, plugin.getMessages().get("admin.menu.info"), plugin.getMessages().get("admin.menu.info-lore")));
         player.openInventory(inv);
     }
 
-    private ItemStack item(Material mat, Object name) {
+    private ItemStack icon(Material mat, String name, String lore) {
         ItemStack it = new ItemStack(mat);
-        ItemMeta meta = it.getItemMeta();
-        if (meta != null) {
-            String display = ChatColor.translateAlternateColorCodes('&', String.valueOf(name));
-            meta.setDisplayName(display);
-            it.setItemMeta(meta);
+        ItemMeta im = it.getItemMeta();
+        if (im != null) {
+            im.setDisplayName(ChatColor.translateAlternateColorCodes('&', String.valueOf(name)));
+            if (lore != null && !lore.isEmpty())
+                im.setLore(java.util.List.of(ChatColor.translateAlternateColorCodes('&', lore)));
+            it.setItemMeta(im);
         }
         return it;
     }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -33,7 +33,9 @@ command:
   join-usage: "&cUsage: /bw join <arène>"
   unknown: "&cSous-commande inconnue"
 admin:
-  menu-title: "&6Gestion BedWars"
+  menu-title: "&8Gestion BedWars"
+  diagnostics-title: "&8Diagnostics"
+  reset-title: "&8Reset d'arène"
   menu:
     arenas: "&eArènes"
     create: "&aCréer une arène"
@@ -41,8 +43,12 @@ admin:
     rules: "&bRègles de jeu"
     npc: "&dHologrammes/PNJ"
     rotation: "&dRotation & Reset"
-    diagnostics: "&cDiagnostics"
+    diagnostics: "&bDiagnostics"
+    diagnostics-lore: "&7État, compteurs, cleanup"
+    reset: "&cReset"
+    reset-lore: "&7Stratégie de reset & test"
     info: "&fRetour / Infos"
+    info-lore: "&7Aide & raccourcis commandes"
 debug:
   header: "&6Statut de l'arène &e{arena}&6:"    
   state: "&7État: &e{state}"


### PR DESCRIPTION
## Summary
- fix admin menu Diagnostics/Reset icons and info button
- add Diagnostics/Reset titles and lore in messages.yml
- unify icon helper for menu items

## Testing
- `mvn -q -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ba3b7e2748329b0b7e5b156d8d1ee