### PR TITLE
feat: add basic generator scheduler

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -7,6 +7,7 @@ import com.example.bedwars.gui.MenuManager;
 import com.example.bedwars.gui.*;
 import com.example.bedwars.listener.PlayerListener;
 import com.example.bedwars.util.MessageManager;
+import com.example.bedwars.generator.GeneratorManager;
 import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -21,6 +22,7 @@ public class BedwarsPlugin extends JavaPlugin {
     private ArenaManager arenaManager;
     private MessageManager messageManager;
     private MenuManager menuManager;
+    private GeneratorManager generatorManager;
     private NamespacedKey arenaKey;
 
     @Override
@@ -29,6 +31,7 @@ public class BedwarsPlugin extends JavaPlugin {
         this.messageManager = new MessageManager(this);
         this.arenaManager = new ArenaManager(this);
         this.menuManager = new MenuManager(this);
+        this.generatorManager = new GeneratorManager(this);
         // Register menus
         menuManager.register(new RootMenu(this));
         menuManager.register(new ArenasMenu(this));
@@ -63,6 +66,10 @@ public class BedwarsPlugin extends JavaPlugin {
 
     public MenuManager getMenuManager() {
         return menuManager;
+    }
+
+    public GeneratorManager getGeneratorManager() {
+        return generatorManager;
     }
 
     /**

--- a/src/main/java/com/example/bedwars/arena/Arena.java
+++ b/src/main/java/com/example/bedwars/arena/Arena.java
@@ -80,6 +80,7 @@ public class Arena {
                 if (countdown <= 0) {
                     state = GameState.RUNNING;
                     broadcast(plugin.getMessages().get("arena.started", Map.of("arena", name)));
+                    plugin.getGeneratorManager().onArenaStart(name);
                     cancel();
                     return;
                 }

--- a/src/main/java/com/example/bedwars/generator/Generator.java
+++ b/src/main/java/com/example/bedwars/generator/Generator.java
@@ -1,0 +1,40 @@
+package com.example.bedwars.generator;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Represents a single resource generator in an arena.
+ */
+public class Generator {
+
+    private final GeneratorType type;
+    private final Location location;
+    private final int intervalTicks;
+    private final int amount;
+    private int counter;
+
+    public Generator(GeneratorType type, Location location, int intervalTicks, int amount) {
+        this.type = type;
+        this.location = location;
+        this.intervalTicks = intervalTicks;
+        this.amount = amount;
+        this.counter = intervalTicks;
+    }
+
+    public void tick() {
+        counter -= 20; // called once per second
+        if (counter <= 0) {
+            World world = location.getWorld();
+            if (world != null) {
+                world.dropItemNaturally(location, new ItemStack(type.getDrop(), amount));
+            }
+            counter = intervalTicks;
+        }
+    }
+
+    public void reset() {
+        this.counter = intervalTicks;
+    }
+}

--- a/src/main/java/com/example/bedwars/generator/GeneratorManager.java
+++ b/src/main/java/com/example/bedwars/generator/GeneratorManager.java
@@ -1,0 +1,100 @@
+package com.example.bedwars.generator;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.GameState;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Entity;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.*;
+
+/**
+ * Central scheduler for arena resource generators.
+ */
+public class GeneratorManager {
+
+    private final BedwarsPlugin plugin;
+    private final Map<GeneratorType, Settings> defaults = new EnumMap<>(GeneratorType.class);
+    private final Map<String, List<Generator>> generators = new HashMap<>();
+    private final NamespacedKey genMarkerKey;
+
+    private record Settings(int interval, int amount) {}
+
+    public GeneratorManager(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+        this.genMarkerKey = new NamespacedKey(plugin, "bw_gen_marker");
+        loadDefaults();
+        startTask();
+    }
+
+    private void loadDefaults() {
+        ConfigurationSection section = plugin.getConfig().getConfigurationSection("generators");
+        if (section == null) {
+            return;
+        }
+        for (String key : section.getKeys(false)) {
+            try {
+                GeneratorType type = GeneratorType.valueOf(key.toUpperCase(Locale.ROOT));
+                int interval = section.getInt(key + ".interval", 200);
+                int amount = section.getInt(key + ".amount", 1);
+                defaults.put(type, new Settings(interval, amount));
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+    }
+
+    private void startTask() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Arena arena : plugin.getArenaManager().getArenas().values()) {
+                    if (arena.getState() != GameState.RUNNING) {
+                        continue;
+                    }
+                    List<Generator> list = generators.get(arena.getName());
+                    if (list != null) {
+                        list.forEach(Generator::tick);
+                    }
+                }
+            }
+        }.runTaskTimer(plugin, 20L, 20L);
+    }
+
+    public void addGenerator(String arenaId, GeneratorType type, org.bukkit.Location loc) {
+        Settings settings = defaults.get(type);
+        if (settings == null) {
+            return;
+        }
+        generators.computeIfAbsent(arenaId, k -> new ArrayList<>())
+                .add(new Generator(type, loc, settings.interval, settings.amount));
+    }
+
+    public void onArenaStart(String arenaId) {
+        List<Generator> list = generators.get(arenaId);
+        if (list != null) {
+            list.forEach(Generator::reset);
+        }
+        removeGenMarkers(arenaId);
+    }
+
+    /**
+     * Remove setup markers tagged for the given arena.
+     */
+    public void removeGenMarkers(String arenaId) {
+        NamespacedKey arenaKey = plugin.getArenaKey();
+        for (World world : plugin.getServer().getWorlds()) {
+            for (Entity entity : world.getEntities()) {
+                PersistentDataContainer pdc = entity.getPersistentDataContainer();
+                if (arenaId.equals(pdc.get(arenaKey, PersistentDataType.STRING))
+                        && pdc.has(genMarkerKey, PersistentDataType.BYTE)) {
+                    entity.remove();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/bedwars/generator/GeneratorType.java
+++ b/src/main/java/com/example/bedwars/generator/GeneratorType.java
@@ -1,0 +1,23 @@
+package com.example.bedwars.generator;
+
+import org.bukkit.Material;
+
+/**
+ * Types of resource generators supported by the plugin.
+ */
+public enum GeneratorType {
+    IRON(Material.IRON_INGOT),
+    GOLD(Material.GOLD_INGOT),
+    DIAMOND(Material.DIAMOND),
+    EMERALD(Material.EMERALD);
+
+    private final Material drop;
+
+    GeneratorType(Material drop) {
+        this.drop = drop;
+    }
+
+    public Material getDrop() {
+        return drop;
+    }
+}


### PR DESCRIPTION
## Summary
- add central generator manager with config-based drop scheduling
- reset generator timers and remove setup markers when games start

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ba65616a48329b32de867a38acb4c