### PR TITLE
fix: commands+menu wiring and min playable core

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -8,6 +8,7 @@ import com.example.bedwars.gui.*;
 import com.example.bedwars.listener.PlayerListener;
 import com.example.bedwars.util.MessageManager;
 import com.example.bedwars.generator.GeneratorManager;
+import com.example.bedwars.scoreboard.ScoreboardManager;
 import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -23,6 +24,7 @@ public class BedwarsPlugin extends JavaPlugin {
     private MessageManager messageManager;
     private MenuManager menuManager;
     private GeneratorManager generatorManager;
+    private ScoreboardManager scoreboardManager;
     private NamespacedKey arenaKey;
 
     @Override
@@ -32,6 +34,7 @@ public class BedwarsPlugin extends JavaPlugin {
         this.arenaManager = new ArenaManager(this);
         this.menuManager = new MenuManager(this);
         this.generatorManager = new GeneratorManager(this);
+        this.scoreboardManager = new ScoreboardManager(this);
         // Register menus
         menuManager.register(new RootMenu(this));
         menuManager.register(new ArenasMenu(this));
@@ -46,7 +49,9 @@ public class BedwarsPlugin extends JavaPlugin {
         this.arenaKey = new NamespacedKey(this, "bw_arena");
 
         // Register command executors
-        getCommand("bw").setExecutor(new BedwarsCommand(this));
+        BedwarsCommand bwCmd = new BedwarsCommand(this);
+        getCommand("bw").setExecutor(bwCmd);
+        getCommand("bw").setTabCompleter(bwCmd);
         AdminCommand adminCmd = new AdminCommand(this);
         getCommand("bwadmin").setExecutor(adminCmd);
         getCommand("bwadmin").setTabCompleter(adminCmd);
@@ -70,6 +75,10 @@ public class BedwarsPlugin extends JavaPlugin {
 
     public GeneratorManager getGeneratorManager() {
         return generatorManager;
+    }
+
+    public ScoreboardManager getScoreboardManager() {
+        return scoreboardManager;
     }
 
     /**

--- a/src/main/java/com/example/bedwars/arena/Arena.java
+++ b/src/main/java/com/example/bedwars/arena/Arena.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Collections;
 
 /**
  * Simplified arena model. Only handles joining, leaving and a very
@@ -62,6 +63,7 @@ public class Arena {
         if (state == GameState.WAITING && players.size() >= 2) {
             startCountdown();
         }
+        plugin.getScoreboardManager().update(this);
     }
 
     public void removePlayer(Player player) {
@@ -70,6 +72,7 @@ public class Arena {
         if (players.isEmpty() && state != GameState.WAITING) {
             reset();
         }
+        plugin.getScoreboardManager().update(this);
     }
 
     private void startCountdown() {
@@ -94,6 +97,13 @@ public class Arena {
         state = GameState.WAITING;
         countdown = 10;
         eventsEnabled = true;
+    }
+
+    /**
+     * Expose current players for scoreboard updates.
+     */
+    public Set<UUID> getPlayers() {
+        return Collections.unmodifiableSet(players);
     }
 
     private void broadcast(String msg) {

--- a/src/main/java/com/example/bedwars/command/BedwarsCommand.java
+++ b/src/main/java/com/example/bedwars/command/BedwarsCommand.java
@@ -4,6 +4,7 @@ import com.example.bedwars.BedwarsPlugin;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 
 import java.util.Map;
@@ -13,7 +14,7 @@ import java.util.Map;
  * specification: list, join and leave. This is meant as a convenience
  * for manual testing of the skeleton plugin.
  */
-public class BedwarsCommand implements CommandExecutor {
+public class BedwarsCommand implements CommandExecutor, TabCompleter {
 
     private final BedwarsPlugin plugin;
 
@@ -54,6 +55,10 @@ public class BedwarsCommand implements CommandExecutor {
                     player.sendMessage(plugin.getMessages().get("command.join-usage"));
                     return true;
                 }
+                if (!player.hasPermission("bedwars.join")) {
+                    player.sendMessage(plugin.getMessages().get("error.not_admin"));
+                    return true;
+                }
                 plugin.getArenaManager().joinArena(player, args[1]);
                 return true;
             }
@@ -66,5 +71,24 @@ public class BedwarsCommand implements CommandExecutor {
                 return true;
             }
         }
+    }
+
+    @Override
+    public java.util.List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!(sender instanceof Player player)) {
+            return java.util.Collections.emptyList();
+        }
+        if (args.length == 1) {
+            java.util.List<String> base = new java.util.ArrayList<>();
+            base.add("menu");
+            base.add("list");
+            base.add("join");
+            base.add("leave");
+            return base;
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("join")) {
+            return new java.util.ArrayList<>(plugin.getArenaManager().getArenas().keySet());
+        }
+        return java.util.Collections.emptyList();
     }
 }

--- a/src/main/java/com/example/bedwars/scoreboard/ScoreboardManager.java
+++ b/src/main/java/com/example/bedwars/scoreboard/ScoreboardManager.java
@@ -1,0 +1,45 @@
+package com.example.bedwars.scoreboard;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+
+import java.util.UUID;
+
+/**
+ * Minimal scoreboard that displays player counts per arena.
+ */
+public class ScoreboardManager {
+
+    private final BedwarsPlugin plugin;
+
+    public ScoreboardManager(BedwarsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Update the scoreboard for all players currently in the arena.
+     * The board simply shows the arena name and number of players.
+     */
+    public void update(Arena arena) {
+        for (UUID uuid : arena.getPlayers()) {
+            Player p = Bukkit.getPlayer(uuid);
+            if (p == null) {
+                continue;
+            }
+            Scoreboard board = Bukkit.getScoreboardManager().getNewScoreboard();
+            Objective obj = board.registerNewObjective("bedwars", "dummy", ChatColor.GOLD + "BedWars");
+            obj.setDisplaySlot(DisplaySlot.SIDEBAR);
+            obj.getScore(ChatColor.YELLOW + "Arène:").setScore(2);
+            obj.getScore(ChatColor.WHITE + arena.getName()).setScore(1);
+            obj.getScore(ChatColor.YELLOW + "Joueurs:").setScore(0);
+            obj.getScore(ChatColor.WHITE + String.valueOf(arena.getPlayerCount())).setScore(-1);
+            p.setScoreboard(board);
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ commands:
   bw:
     description: Menu BedWars + commandes
     usage: /bw
-    permission: bedwars.admin
+    aliases: [bedwars]
   bwadmin:
     description: Commandes d'administration BedWars
     usage: /bwadmin
@@ -21,6 +21,12 @@ permissions:
       bedwars.admin: true
       bedwars.admin.arena: true
       bedwars.admin.game: true
+      bedwars.admin.team: true
+      bedwars.admin.npc: true
+      bedwars.admin.gen: true
+      bedwars.admin.rules: true
+      bedwars.admin.debug: true
+      bedwars.admin.maintenance: true
   bedwars.admin:
     description: Accès au menu de gestion
     default: op
@@ -29,6 +35,24 @@ permissions:
     default: op
   bedwars.admin.game:
     description: Gestion des événements de jeu
+    default: op
+  bedwars.admin.team:
+    description: Gestion des équipes
+    default: op
+  bedwars.admin.npc:
+    description: Gestion des PNJ/Boutiques
+    default: op
+  bedwars.admin.gen:
+    description: Gestion des générateurs
+    default: op
+  bedwars.admin.rules:
+    description: Gestion des règles
+    default: op
+  bedwars.admin.debug:
+    description: Diagnostics
+    default: op
+  bedwars.admin.maintenance:
+    description: Maintenance/cleanup
     default: op
   bedwars.join:
     description: Rejoindre une arène


### PR DESCRIPTION
## Summary
- add tab completion and join permission handling for /bw command
- register commands with tab completers and expose scoreboard manager
- introduce minimal scoreboard to display arena and player count
- extend plugin.yml with command alias and granular admin permissions

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:3.3.1 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_689ba9db85a4832988ea6c437bc66b43