### PR TITLE
feat: define BedWars domain model and APIs

### DIFF
--- a/src/main/java/com/example/bedwars/api/ArenaApi.java
+++ b/src/main/java/com/example/bedwars/api/ArenaApi.java
@@ -1,0 +1,32 @@
+package com.example.bedwars.api;
+
+import com.example.bedwars.arena.*;
+import com.example.bedwars.gen.*;
+import com.example.bedwars.shop.*;
+import org.bukkit.Location;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Management operations for arenas.
+ */
+public interface ArenaApi {
+  Collection<Arena> all();
+  Optional<Arena> get(String id);
+
+  Arena create(String id, WorldRef world);
+  boolean delete(String id);
+
+  void setLobby(String id, Location lobby);
+  void enableTeam(String id, TeamColor team);
+  void disableTeam(String id, TeamColor team);
+  void setTeamSpawn(String id, TeamColor team, Location spawn);
+  void setTeamBed(String id, TeamColor team, Location bedBlock);
+
+  Generator addGenerator(String id, GeneratorType type, Location loc, int tier);
+  void removeGenerator(String id, java.util.UUID generatorId);
+
+  NpcData addNpc(String id, NpcType type, Location loc);
+  void removeNpc(String id, java.util.UUID npcId);
+}

--- a/src/main/java/com/example/bedwars/api/GameApi.java
+++ b/src/main/java/com/example/bedwars/api/GameApi.java
@@ -1,0 +1,11 @@
+package com.example.bedwars.api;
+
+import com.example.bedwars.arena.Arena;
+
+/**
+ * Arena game state machine API.
+ */
+public interface GameApi {
+  void start(Arena arena) throws IllegalStateException;
+  void stop(Arena arena);
+}

--- a/src/main/java/com/example/bedwars/api/SetupApi.java
+++ b/src/main/java/com/example/bedwars/api/SetupApi.java
@@ -1,0 +1,12 @@
+package com.example.bedwars.api;
+
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.TeamColor;
+
+/**
+ * Validation helpers for arena setup.
+ */
+public interface SetupApi {
+  boolean isArenaReady(Arena a);
+  boolean isTeamConfigured(Arena a, TeamColor t);
+}

--- a/src/main/java/com/example/bedwars/arena/Arena.java
+++ b/src/main/java/com/example/bedwars/arena/Arena.java
@@ -1,0 +1,48 @@
+package com.example.bedwars.arena;
+
+import com.example.bedwars.gen.Generator;
+import com.example.bedwars.shop.NpcData;
+
+import org.bukkit.Location;
+import java.util.*;
+
+/**
+ * Representation of a BedWars arena with teams, generators and NPCs.
+ */
+public final class Arena {
+  private final String id;
+  private WorldRef world;
+  private GameState state = GameState.WAITING;
+
+  private Location lobby; // null if undefined
+  private final EnumSet<TeamColor> enabledTeams = EnumSet.noneOf(TeamColor.class);
+  private final EnumMap<TeamColor, TeamData> teams = new EnumMap<>(TeamColor.class);
+  private final List<Generator> generators = new ArrayList<>();
+  private final List<NpcData> npcs = new ArrayList<>();
+
+  public Arena(String id, WorldRef world) {
+    this.id = Objects.requireNonNull(id);
+    this.world = Objects.requireNonNull(world);
+    for (TeamColor c : TeamColor.values()) teams.put(c, new TeamData());
+  }
+
+  public String id() { return id; }
+  public WorldRef world() { return world; }
+  public GameState state() { return state; }
+  public Location lobby() { return lobby; }
+  public Set<TeamColor> enabledTeams() { return Collections.unmodifiableSet(enabledTeams); }
+  public Map<TeamColor, TeamData> teams() { return Collections.unmodifiableMap(teams); }
+  public List<Generator> generators() { return Collections.unmodifiableList(generators); }
+  public List<NpcData> npcs() { return Collections.unmodifiableList(npcs); }
+
+  public Arena setWorld(WorldRef world) { this.world = Objects.requireNonNull(world); return this; }
+  public Arena setState(GameState s) { this.state = Objects.requireNonNull(s); return this; }
+  public Arena setLobby(Location lobby) { this.lobby = Objects.requireNonNull(lobby); return this; }
+
+  public Arena enableTeam(TeamColor c) { enabledTeams.add(c); return this; }
+  public Arena disableTeam(TeamColor c) { enabledTeams.remove(c); return this; }
+
+  public TeamData team(TeamColor c) { return teams.get(c); }
+  public Arena addGenerator(Generator g) { generators.add(Objects.requireNonNull(g)); return this; }
+  public Arena addNpc(NpcData n) { npcs.add(Objects.requireNonNull(n)); return this; }
+}

--- a/src/main/java/com/example/bedwars/arena/GameState.java
+++ b/src/main/java/com/example/bedwars/arena/GameState.java
@@ -1,0 +1,8 @@
+package com.example.bedwars.arena;
+
+/**
+ * Lifecycle state of an arena.
+ */
+public enum GameState {
+  WAITING, STARTING, RUNNING, ENDING, RESTARTING
+}

--- a/src/main/java/com/example/bedwars/arena/TeamColor.java
+++ b/src/main/java/com/example/bedwars/arena/TeamColor.java
@@ -1,0 +1,26 @@
+package com.example.bedwars.arena;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+
+/**
+ * Colors and metadata for teams.
+ */
+public enum TeamColor {
+  RED("Rouge", ChatColor.RED, Material.RED_WOOL),
+  BLUE("Bleu", ChatColor.BLUE, Material.BLUE_WOOL),
+  GREEN("Vert", ChatColor.GREEN, Material.GREEN_WOOL),
+  YELLOW("Jaune", ChatColor.YELLOW, Material.YELLOW_WOOL),
+  AQUA("Aqua", ChatColor.AQUA, Material.LIGHT_BLUE_WOOL),
+  WHITE("Blanc", ChatColor.WHITE, Material.WHITE_WOOL),
+  PINK("Rose", ChatColor.LIGHT_PURPLE, Material.PINK_WOOL),
+  GRAY("Gris", ChatColor.GRAY, Material.GRAY_WOOL);
+
+  public final String display;
+  public final ChatColor color;
+  public final Material wool;
+
+  TeamColor(String display, ChatColor color, Material wool) {
+    this.display = display; this.color = color; this.wool = wool;
+  }
+}

--- a/src/main/java/com/example/bedwars/arena/TeamData.java
+++ b/src/main/java/com/example/bedwars/arena/TeamData.java
@@ -1,0 +1,21 @@
+package com.example.bedwars.arena;
+
+import org.bukkit.Location;
+import java.util.Objects;
+
+/**
+ * Data describing a team in an arena.
+ */
+public final class TeamData {
+  private Location spawn;        // null until defined
+  private Location bedBlock;     // "head" block of the bed
+  private int maxPlayers = 4;
+
+  public Location spawn() { return spawn; }
+  public Location bedBlock() { return bedBlock; }
+  public int maxPlayers() { return maxPlayers; }
+
+  public TeamData setSpawn(Location loc) { this.spawn = Objects.requireNonNull(loc); return this; }
+  public TeamData setBedBlock(Location loc) { this.bedBlock = Objects.requireNonNull(loc); return this; }
+  public TeamData setMaxPlayers(int max) { this.maxPlayers = Math.max(1, max); return this; }
+}

--- a/src/main/java/com/example/bedwars/arena/WorldRef.java
+++ b/src/main/java/com/example/bedwars/arena/WorldRef.java
@@ -1,0 +1,6 @@
+package com.example.bedwars.arena;
+
+/**
+ * Reference to a world by name.
+ */
+public record WorldRef(String name) { }

--- a/src/main/java/com/example/bedwars/gen/Generator.java
+++ b/src/main/java/com/example/bedwars/gen/Generator.java
@@ -1,0 +1,34 @@
+package com.example.bedwars.gen;
+
+import org.bukkit.Location;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Resource generator spawning items over time.
+ */
+public final class Generator {
+  private final UUID id = UUID.randomUUID();
+  private final GeneratorType type;
+  private Location location;
+  private int tier = 1;
+  private int intervalTicks = 20 * 120; // default interval
+  private int amount = 1;
+
+  public Generator(GeneratorType type, Location location) {
+    this.type = Objects.requireNonNull(type);
+    this.location = Objects.requireNonNull(location);
+  }
+
+  public UUID id() { return id; }
+  public GeneratorType type() { return type; }
+  public Location location() { return location; }
+  public int tier() { return tier; }
+  public int intervalTicks() { return intervalTicks; }
+  public int amount() { return amount; }
+
+  public Generator setLocation(Location loc) { this.location = Objects.requireNonNull(loc); return this; }
+  public Generator setTier(int tier) { this.tier = Math.max(1, Math.min(3, tier)); return this; }
+  public Generator setIntervalTicks(int ticks) { this.intervalTicks = Math.max(1, ticks); return this; }
+  public Generator setAmount(int amount) { this.amount = Math.max(1, amount); return this; }
+}

--- a/src/main/java/com/example/bedwars/gen/GeneratorType.java
+++ b/src/main/java/com/example/bedwars/gen/GeneratorType.java
@@ -1,0 +1,6 @@
+package com.example.bedwars.gen;
+
+/**
+ * Types of item generators.
+ */
+public enum GeneratorType { IRON, GOLD, DIAMOND, EMERALD }

--- a/src/main/java/com/example/bedwars/ops/Keys.java
+++ b/src/main/java/com/example/bedwars/ops/Keys.java
@@ -1,0 +1,19 @@
+package com.example.bedwars.ops;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.NamespacedKey;
+
+/**
+ * Centralised PersistentDataContainer keys used by the plugin.
+ */
+public final class Keys {
+  private static NamespacedKey key(String s){ return new NamespacedKey(BedwarsPlugin.get(), s); }
+
+  public static final NamespacedKey ARENA_ID    = key("bw_arena");
+  public static final NamespacedKey NPC_KIND    = key("bw_npc");         // "item" / "upgrade"
+  public static final NamespacedKey GEN_MARKER  = key("bw_gen_marker");  // markers setup
+  public static final NamespacedKey GEN_KIND    = key("bw_gen");         // "IRON"/"GOLD"/...
+  public static final NamespacedKey HOLO_KIND   = key("bw_holo");        // "diamond"/"emerald"
+
+  private Keys() {}
+}

--- a/src/main/java/com/example/bedwars/shop/NpcData.java
+++ b/src/main/java/com/example/bedwars/shop/NpcData.java
@@ -1,0 +1,25 @@
+package com.example.bedwars.shop;
+
+import org.bukkit.Location;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Data for a shop NPC.
+ */
+public final class NpcData {
+  private final UUID id = UUID.randomUUID();
+  private final NpcType type;
+  private Location location;
+
+  public NpcData(NpcType type, Location location) {
+    this.type = Objects.requireNonNull(type);
+    this.location = Objects.requireNonNull(location);
+  }
+
+  public UUID id() { return id; }
+  public NpcType type() { return type; }
+  public Location location() { return location; }
+
+  public NpcData setLocation(Location location) { this.location = Objects.requireNonNull(location); return this; }
+}

--- a/src/main/java/com/example/bedwars/shop/NpcType.java
+++ b/src/main/java/com/example/bedwars/shop/NpcType.java
@@ -1,0 +1,6 @@
+package com.example.bedwars.shop;
+
+/**
+ * Types of shop NPCs.
+ */
+public enum NpcType { ITEM, UPGRADE }

--- a/src/main/java/com/example/bedwars/shop/TrapType.java
+++ b/src/main/java/com/example/bedwars/shop/TrapType.java
@@ -1,0 +1,8 @@
+package com.example.bedwars.shop;
+
+/**
+ * Types of defensive traps.
+ */
+public enum TrapType {
+  ALARM, MINING_FATIGUE, COUNTER_OFFENSIVE
+}

--- a/src/main/java/com/example/bedwars/shop/UpgradeType.java
+++ b/src/main/java/com/example/bedwars/shop/UpgradeType.java
@@ -1,0 +1,8 @@
+package com.example.bedwars.shop;
+
+/**
+ * Possible upgrade types for teams.
+ */
+public enum UpgradeType {
+  SHARPNESS, PROTECTION, MANIC_MINER, HEAL_POOL, FORGE
+}


### PR DESCRIPTION
## Summary
- add enums for teams, game state, generators, NPCs, upgrades, and traps
- implement core POJOs for arenas, teams, generators, and NPCs
- expose internal APIs for arena management, setup validation, and game lifecycle
- centralize persistent data container keys

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bc52489448329a8cb66df0456b1d4