### PR TITLE
feat: add admin menu infrastructure

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -6,12 +6,15 @@ import com.example.bedwars.util.Messages;
 import com.example.bedwars.command.BwCommand;
 import com.example.bedwars.command.BwAdminCommand;
 import com.example.bedwars.arena.ArenaManager;
+import com.example.bedwars.gui.MenuManager;
+import com.example.bedwars.listeners.MenuListener;
 
 public final class BedwarsPlugin extends JavaPlugin {
 
   private static BedwarsPlugin instance;
   private Messages messages;
   private ArenaManager arenaManager;
+  private MenuManager menuManager;
 
   @Override
   public void onEnable() {
@@ -20,9 +23,12 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.messages = new Messages(this);
     this.arenaManager = new ArenaManager(this);
     this.arenaManager.loadAll();
+    this.menuManager = new MenuManager(this);
 
     Objects.requireNonNull(getCommand("bw")).setExecutor(new BwCommand(this));
     Objects.requireNonNull(getCommand("bwadmin")).setExecutor(new BwAdminCommand(this));
+
+    getServer().getPluginManager().registerEvents(new MenuListener(this), this);
 
     getLogger().info("Bedwars loaded.");
   }
@@ -43,5 +49,9 @@ public final class BedwarsPlugin extends JavaPlugin {
 
   public ArenaManager arenas() {
     return arenaManager;
+  }
+
+  public MenuManager menus() {
+    return menuManager;
   }
 }

--- a/src/main/java/com/example/bedwars/command/BwCommand.java
+++ b/src/main/java/com/example/bedwars/command/BwCommand.java
@@ -1,6 +1,7 @@
 package com.example.bedwars.command;
 
 import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.AdminView;
 import java.util.List;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -18,6 +19,14 @@ public final class BwCommand implements CommandExecutor {
   public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
     if (!(sender instanceof Player player)) {
       sender.sendMessage("Player only.");
+      return true;
+    }
+    if (args.length >= 1 && args[0].equalsIgnoreCase("menu")) {
+      if (!player.hasPermission("bedwars.admin")) {
+        player.sendMessage(plugin.messages().get("admin.no-perm"));
+        return true;
+      }
+      plugin.menus().open(AdminView.ROOT, player, null);
       return true;
     }
     List<String> lines = plugin.messages().getList("help.player");

--- a/src/main/java/com/example/bedwars/gui/AdminView.java
+++ b/src/main/java/com/example/bedwars/gui/AdminView.java
@@ -1,0 +1,14 @@
+package com.example.bedwars.gui;
+
+public enum AdminView {
+  ROOT,
+  ARENAS,
+  ARENA_EDITOR,
+  RULES_EVENTS,
+  NPC_SHOPS,
+  GENERATORS,
+  ROTATION,
+  RESET,
+  DIAGNOSTICS,
+  INFO
+}

--- a/src/main/java/com/example/bedwars/gui/BWMenuHolder.java
+++ b/src/main/java/com/example/bedwars/gui/BWMenuHolder.java
@@ -1,0 +1,19 @@
+package com.example.bedwars.gui;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public final class BWMenuHolder implements InventoryHolder {
+  public final AdminView view;
+  public final String arenaId; // null sur ROOT ou vues globales
+
+  public BWMenuHolder(AdminView view, String arenaId) {
+    this.view = view;
+    this.arenaId = arenaId;
+  }
+
+  @Override
+  public Inventory getInventory() {
+    return null; // non utilisé
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/MenuManager.java
+++ b/src/main/java/com/example/bedwars/gui/MenuManager.java
@@ -1,0 +1,46 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.entity.Player;
+
+public final class MenuManager {
+  private final BedwarsPlugin plugin;
+  private final RootMenu root;
+  // placeholders :
+  private final placeholders.ArenasMenu arenas;
+  private final placeholders.RulesEventsMenu rules;
+  private final placeholders.NpcShopsMenu shops;
+  private final placeholders.GeneratorsMenu gens;
+  private final placeholders.RotationMenu rotation;
+  private final placeholders.ResetMenu reset;
+  private final placeholders.DiagnosticsMenu diag;
+  private final placeholders.InfoMenu info;
+
+  public MenuManager(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+    this.root = new RootMenu(plugin);
+    this.arenas = new placeholders.ArenasMenu(plugin);
+    this.rules = new placeholders.RulesEventsMenu(plugin);
+    this.shops = new placeholders.NpcShopsMenu(plugin);
+    this.gens = new placeholders.GeneratorsMenu(plugin);
+    this.rotation = new placeholders.RotationMenu(plugin);
+    this.reset = new placeholders.ResetMenu(plugin);
+    this.diag = new placeholders.DiagnosticsMenu(plugin);
+    this.info = new placeholders.InfoMenu(plugin);
+  }
+
+  public void open(AdminView v, Player p, String arenaId) {
+    switch (v) {
+      case ROOT -> root.open(p);
+      case ARENAS -> arenas.open(p);
+      case RULES_EVENTS -> rules.open(p);
+      case NPC_SHOPS -> shops.open(p);
+      case GENERATORS -> gens.open(p);
+      case ROTATION -> rotation.open(p);
+      case RESET -> reset.open(p);
+      case DIAGNOSTICS -> diag.open(p);
+      case INFO -> info.open(p);
+      default -> root.open(p);
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/RootMenu.java
+++ b/src/main/java/com/example/bedwars/gui/RootMenu.java
@@ -1,0 +1,57 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+public final class RootMenu {
+  private final BedwarsPlugin plugin;
+
+  // mapping slots
+  public static final int SLOT_ARENAS = 10;
+  public static final int SLOT_CREATE = 12;
+  public static final int SLOT_RULES = 14;
+  public static final int SLOT_SHOPS = 16;
+  public static final int SLOT_GENS = 28;
+  public static final int SLOT_ROTATION = 30;
+  public static final int SLOT_RESET = 32;
+  public static final int SLOT_DIAG = 34;
+  public static final int SLOT_INFO = 49;
+
+  public RootMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p) {
+    String title = plugin.messages().get("admin.menu-title");
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.ROOT, null), 54, title);
+    inv.setItem(SLOT_ARENAS, icon(Material.MAP,       "admin.root.arenas",     "admin.root.arenas-lore"));
+    inv.setItem(SLOT_CREATE, icon(Material.LIME_WOOL, "admin.root.create",     "admin.root.create-lore"));
+    inv.setItem(SLOT_RULES,  icon(Material.BOOK,      "admin.root.rules",      "admin.root.rules-lore"));
+    inv.setItem(SLOT_SHOPS,  icon(Material.EMERALD,   "admin.root.shops",      "admin.root.shops-lore"));
+    inv.setItem(SLOT_GENS,   icon(Material.HOPPER,    "admin.root.generators", "admin.root.generators-lore"));
+    inv.setItem(SLOT_ROTATION, icon(Material.COMPASS, "admin.root.rotation",   "admin.root.rotation-lore"));
+    inv.setItem(SLOT_RESET,  icon(Material.BARRIER,   "admin.root.reset",      "admin.root.reset-lore"));
+    inv.setItem(SLOT_DIAG,   icon(Material.REDSTONE_COMPARATOR, "admin.root.diagnostics","admin.root.diagnostics-lore"));
+    inv.setItem(SLOT_INFO,   icon(Material.PAPER,     "admin.root.info",       "admin.root.info-lore"));
+    p.openInventory(inv);
+  }
+
+  private ItemStack icon(Material mat, String nameKey, String loreKey) {
+    ItemStack it = new ItemStack(mat);
+    ItemMeta im = it.getItemMeta();
+    if (im != null) {
+      String name = plugin.messages().get(nameKey);
+      String lore = plugin.messages().get(loreKey);
+      im.setDisplayName(name);
+      im.setLore(List.of(ChatColor.GRAY + ChatColor.stripColor(lore)));
+      it.setItemMeta(im);
+    }
+    return it;
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/placeholders/ArenasMenu.java
+++ b/src/main/java/com/example/bedwars/gui/placeholders/ArenasMenu.java
@@ -1,0 +1,20 @@
+package com.example.bedwars.gui.placeholders;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.AdminView;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class ArenasMenu {
+  private final BedwarsPlugin plugin;
+  public ArenasMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p) {
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.ARENAS, null), 54,
+        plugin.messages().get("admin.root.arenas"));
+    // Étape 4 : on remplira la liste / les boutons CRUD
+    p.openInventory(inv);
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/placeholders/DiagnosticsMenu.java
+++ b/src/main/java/com/example/bedwars/gui/placeholders/DiagnosticsMenu.java
@@ -1,0 +1,19 @@
+package com.example.bedwars.gui.placeholders;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.AdminView;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class DiagnosticsMenu {
+  private final BedwarsPlugin plugin;
+  public DiagnosticsMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p) {
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.DIAGNOSTICS, null), 54,
+        plugin.messages().get("admin.root.diagnostics"));
+    p.openInventory(inv);
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/placeholders/GeneratorsMenu.java
+++ b/src/main/java/com/example/bedwars/gui/placeholders/GeneratorsMenu.java
@@ -1,0 +1,19 @@
+package com.example.bedwars.gui.placeholders;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.AdminView;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class GeneratorsMenu {
+  private final BedwarsPlugin plugin;
+  public GeneratorsMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p) {
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.GENERATORS, null), 54,
+        plugin.messages().get("admin.root.generators"));
+    p.openInventory(inv);
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/placeholders/InfoMenu.java
+++ b/src/main/java/com/example/bedwars/gui/placeholders/InfoMenu.java
@@ -1,0 +1,19 @@
+package com.example.bedwars.gui.placeholders;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.AdminView;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class InfoMenu {
+  private final BedwarsPlugin plugin;
+  public InfoMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p) {
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.INFO, null), 54,
+        plugin.messages().get("admin.root.info"));
+    p.openInventory(inv);
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/placeholders/NpcShopsMenu.java
+++ b/src/main/java/com/example/bedwars/gui/placeholders/NpcShopsMenu.java
@@ -1,0 +1,19 @@
+package com.example.bedwars.gui.placeholders;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.AdminView;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class NpcShopsMenu {
+  private final BedwarsPlugin plugin;
+  public NpcShopsMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p) {
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.NPC_SHOPS, null), 54,
+        plugin.messages().get("admin.root.shops"));
+    p.openInventory(inv);
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/placeholders/ResetMenu.java
+++ b/src/main/java/com/example/bedwars/gui/placeholders/ResetMenu.java
@@ -1,0 +1,19 @@
+package com.example.bedwars.gui.placeholders;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.AdminView;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class ResetMenu {
+  private final BedwarsPlugin plugin;
+  public ResetMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p) {
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.RESET, null), 54,
+        plugin.messages().get("admin.root.reset"));
+    p.openInventory(inv);
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/placeholders/RotationMenu.java
+++ b/src/main/java/com/example/bedwars/gui/placeholders/RotationMenu.java
@@ -1,0 +1,19 @@
+package com.example.bedwars.gui.placeholders;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.AdminView;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class RotationMenu {
+  private final BedwarsPlugin plugin;
+  public RotationMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p) {
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.ROTATION, null), 54,
+        plugin.messages().get("admin.root.rotation"));
+    p.openInventory(inv);
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/placeholders/RulesEventsMenu.java
+++ b/src/main/java/com/example/bedwars/gui/placeholders/RulesEventsMenu.java
@@ -1,0 +1,19 @@
+package com.example.bedwars.gui.placeholders;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.AdminView;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class RulesEventsMenu {
+  private final BedwarsPlugin plugin;
+  public RulesEventsMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p) {
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(AdminView.RULES_EVENTS, null), 54,
+        plugin.messages().get("admin.root.rules"));
+    p.openInventory(inv);
+  }
+}

--- a/src/main/java/com/example/bedwars/listeners/MenuListener.java
+++ b/src/main/java/com/example/bedwars/listeners/MenuListener.java
@@ -1,0 +1,49 @@
+package com.example.bedwars.listeners;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.*;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+public final class MenuListener implements Listener {
+  private final BedwarsPlugin plugin;
+
+  public MenuListener(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  @EventHandler
+  public void onClick(InventoryClickEvent e) {
+    Inventory top = e.getView().getTopInventory();
+    if (!(top.getHolder() instanceof BWMenuHolder holder)) return;
+
+    // Bloquer toute interaction par défaut
+    e.setCancelled(true);
+    if (!(e.getWhoClicked() instanceof Player p)) return;
+    if (!p.hasPermission("bedwars.admin")) { p.sendMessage(plugin.messages().get("admin.no-perm")); return; }
+    if (e.getClickedInventory() != top) return; // on ignore l'inventaire bas
+    if (e.getCurrentItem() == null) return;
+
+    int slot = e.getRawSlot();
+
+    if (holder.view == AdminView.ROOT) {
+      switch (slot) {
+        case RootMenu.SLOT_ARENAS    -> plugin.menus().open(AdminView.ARENAS, p, null);
+        case RootMenu.SLOT_CREATE    -> plugin.menus().open(AdminView.ARENAS, p, null); // Étape 4: lancera le wizard
+        case RootMenu.SLOT_RULES     -> plugin.menus().open(AdminView.RULES_EVENTS, p, null);
+        case RootMenu.SLOT_SHOPS     -> plugin.menus().open(AdminView.NPC_SHOPS, p, null);
+        case RootMenu.SLOT_GENS      -> plugin.menus().open(AdminView.GENERATORS, p, null);
+        case RootMenu.SLOT_ROTATION  -> plugin.menus().open(AdminView.ROTATION, p, null);
+        case RootMenu.SLOT_RESET     -> plugin.menus().open(AdminView.RESET, p, null);
+        case RootMenu.SLOT_DIAG      -> plugin.menus().open(AdminView.DIAGNOSTICS, p, null);
+        case RootMenu.SLOT_INFO      -> plugin.menus().open(AdminView.INFO, p, null);
+        default -> {}
+      }
+    }
+
+    // Bloquer shift-click, swap, number keys (sécurité UX)
+    if (e.getClick().isShiftClick() || e.getClick() == ClickType.NUMBER_KEY) e.setCancelled(true);
+  }
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -25,3 +25,30 @@ arena.list: "&eArènes: %s"
 arena.exists: "&cL'arène %s existe déjà."
 arena.missing: "&cL'arène %s n'existe pas."
 arena.world-required: "&cMonde requis."
+
+admin:
+  menu-title: "&8Gestion BedWars"
+  no-perm: "&cVous n'avez pas la permission &7(bedwars.admin)."
+
+  root:
+    arenas: "&eArènes"
+    arenas-lore: "&7Lister/éditer les arènes"
+    create: "&aCréer une arène"
+    create-lore: "&7Lancer l'assistant de création"
+    rules: "&6Règles & Événements"
+    rules-lore: "&7Limites de build, timeline"
+    shops: "&bPNJ & Shops"
+    shops-lore: "&7Boutique objets & upgrades"
+    generators: "&3Générateurs"
+    generators-lore: "&7Ajouter/éditer les génés"
+    rotation: "&dRotation"
+    rotation-lore: "&7Liste & poids d'arènes"
+    reset: "&cReset"
+    reset-lore: "&7Stratégie & test de reset"
+    diagnostics: "&9Diagnostics"
+    diagnostics-lore: "&7État, compteurs, cleanup"
+    info: "&fRetour / Infos"
+    info-lore: "&7Aide & raccourcis commandes"
+
+  placeholders:
+    wip: "&7Cette vue sera complétée à l'étape suivante."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,6 +12,11 @@ commands:
     description: Commandes admin BedWars
     usage: /bwadmin <help>
 permissions:
+  bedwars.admin:
+    description: Accès aux commandes admin BedWars
+    default: op
   bedwars.admin.*:
     description: Accès à toutes les commandes admin BedWars
     default: op
+    children:
+      bedwars.admin: true


### PR DESCRIPTION
## Summary
- add admin menu views and holder
- implement root menu and placeholders with slot mapping
- wire `/bw menu` command, listener, and i18n/permissions

### Slot mapping
- 10 Arènes
- 12 Créer
- 14 Règles & Événements
- 16 PNJ & Shops
- 28 Générateurs
- 30 Rotation
- 32 Reset
- 34 Diagnostics
- 49 Infos/Retour

## Testing
- `mvn -q -e test` *(fails: PluginResolutionException: could not transfer artifact due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bcacf712883299a56b76fe725beaf