### PR TITLE
Fix root menu placeholders and material

### DIFF
--- a/src/main/java/com/example/bedwars/gui/MenuManager.java
+++ b/src/main/java/com/example/bedwars/gui/MenuManager.java
@@ -1,32 +1,32 @@
 package com.example.bedwars.gui;
 
 import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.placeholders.*;
 import org.bukkit.entity.Player;
 
 public final class MenuManager {
   private final BedwarsPlugin plugin;
   private final RootMenu root;
-  // placeholders :
-  private final placeholders.ArenasMenu arenas;
-  private final placeholders.RulesEventsMenu rules;
-  private final placeholders.NpcShopsMenu shops;
-  private final placeholders.GeneratorsMenu gens;
-  private final placeholders.RotationMenu rotation;
-  private final placeholders.ResetMenu reset;
-  private final placeholders.DiagnosticsMenu diag;
-  private final placeholders.InfoMenu info;
+  private final ArenasMenu arenas;
+  private final RulesEventsMenu rules;
+  private final NpcShopsMenu shops;
+  private final GeneratorsMenu gens;
+  private final RotationMenu rotation;
+  private final ResetMenu reset;
+  private final DiagnosticsMenu diag;
+  private final InfoMenu info;
 
   public MenuManager(BedwarsPlugin plugin) {
     this.plugin = plugin;
     this.root = new RootMenu(plugin);
-    this.arenas = new placeholders.ArenasMenu(plugin);
-    this.rules = new placeholders.RulesEventsMenu(plugin);
-    this.shops = new placeholders.NpcShopsMenu(plugin);
-    this.gens = new placeholders.GeneratorsMenu(plugin);
-    this.rotation = new placeholders.RotationMenu(plugin);
-    this.reset = new placeholders.ResetMenu(plugin);
-    this.diag = new placeholders.DiagnosticsMenu(plugin);
-    this.info = new placeholders.InfoMenu(plugin);
+    this.arenas = new ArenasMenu(plugin);
+    this.rules = new RulesEventsMenu(plugin);
+    this.shops = new NpcShopsMenu(plugin);
+    this.gens = new GeneratorsMenu(plugin);
+    this.rotation = new RotationMenu(plugin);
+    this.reset = new ResetMenu(plugin);
+    this.diag = new DiagnosticsMenu(plugin);
+    this.info = new InfoMenu(plugin);
   }
 
   public void open(AdminView v, Player p, String arenaId) {

--- a/src/main/java/com/example/bedwars/gui/RootMenu.java
+++ b/src/main/java/com/example/bedwars/gui/RootMenu.java
@@ -37,7 +37,7 @@ public final class RootMenu {
     inv.setItem(SLOT_GENS,   icon(Material.HOPPER,    "admin.root.generators", "admin.root.generators-lore"));
     inv.setItem(SLOT_ROTATION, icon(Material.COMPASS, "admin.root.rotation",   "admin.root.rotation-lore"));
     inv.setItem(SLOT_RESET,  icon(Material.BARRIER,   "admin.root.reset",      "admin.root.reset-lore"));
-    inv.setItem(SLOT_DIAG,   icon(Material.REDSTONE_COMPARATOR, "admin.root.diagnostics","admin.root.diagnostics-lore"));
+    inv.setItem(SLOT_DIAG,   icon(Material.COMPARATOR, "admin.root.diagnostics","admin.root.diagnostics-lore"));
     inv.setItem(SLOT_INFO,   icon(Material.PAPER,     "admin.root.info",       "admin.root.info-lore"));
     p.openInventory(inv);
   }

--- a/src/main/java/com/example/bedwars/listeners/MenuListener.java
+++ b/src/main/java/com/example/bedwars/listeners/MenuListener.java
@@ -44,6 +44,10 @@ public final class MenuListener implements Listener {
     }
 
     // Bloquer shift-click, swap, number keys (sécurité UX)
-    if (e.getClick().isShiftClick() || e.getClick() == ClickType.NUMBER_KEY) e.setCancelled(true);
+    if (e.getClick().isShiftClick() ||
+        e.getClick() == ClickType.NUMBER_KEY ||
+        e.getClick() == ClickType.SWAP_OFFHAND) {
+      e.setCancelled(true);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- fix root admin menu comparator material for 1.21
- wire placeholder admin menus via MenuManager
- harden menu listener against swap clicks

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bcd08b0ec832993568957184ad9e8