### PR TITLE
Step 4 arena editor wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,24 @@ mvn -DskipTests package
 
 Le JAR généré se trouve dans `target/bedwars-0.0.1.jar` et doit être
 placé dans le dossier `plugins/` d'un serveur Paper/Spigot 1.21.
+
+## Éditeur d'arène (Étape 4)
+
+Un assistant permet de créer une arène via le menu admin (laine verte).
+Après saisie de l'identifiant, l'éditeur s'ouvre avec les actions
+suivantes (slots principaux) :
+
+| Slot | Action |
+|-----:|--------|
+| 10 | Définir le lobby |
+| 12 | Ouvrir la gestion des équipes |
+| 14 | Ajouter des PNJ |
+| 16 | Ajouter des générateurs |
+| 28 | Sauvegarder |
+| 30 | Recharger |
+| 32 | Supprimer |
+| 49 | Retour |
+
+Les sous-menus permettent d'activer une équipe, de positionner ses spawns
+et lits, de poser les PNJ boutique/upgrade et d'ajouter les générateurs
+marqués.

--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -8,6 +8,8 @@ import com.example.bedwars.command.BwAdminCommand;
 import com.example.bedwars.arena.ArenaManager;
 import com.example.bedwars.gui.MenuManager;
 import com.example.bedwars.listeners.MenuListener;
+import com.example.bedwars.listeners.EditorListener;
+import com.example.bedwars.setup.PromptService;
 
 public final class BedwarsPlugin extends JavaPlugin {
 
@@ -15,6 +17,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   private Messages messages;
   private ArenaManager arenaManager;
   private MenuManager menuManager;
+  private PromptService promptService;
 
   @Override
   public void onEnable() {
@@ -24,11 +27,14 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.arenaManager = new ArenaManager(this);
     this.arenaManager.loadAll();
     this.menuManager = new MenuManager(this);
+    this.promptService = new PromptService(this);
 
     Objects.requireNonNull(getCommand("bw")).setExecutor(new BwCommand(this));
     Objects.requireNonNull(getCommand("bwadmin")).setExecutor(new BwAdminCommand(this));
 
     getServer().getPluginManager().registerEvents(new MenuListener(this), this);
+    getServer().getPluginManager().registerEvents(new EditorListener(this), this);
+    getServer().getPluginManager().registerEvents(promptService, this);
 
     getLogger().info("Bedwars loaded.");
   }
@@ -53,5 +59,9 @@ public final class BedwarsPlugin extends JavaPlugin {
 
   public MenuManager menus() {
     return menuManager;
+  }
+
+  public PromptService prompts() {
+    return promptService;
   }
 }

--- a/src/main/java/com/example/bedwars/gui/BWMenuHolder.java
+++ b/src/main/java/com/example/bedwars/gui/BWMenuHolder.java
@@ -2,13 +2,22 @@ package com.example.bedwars.gui;
 
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
+import com.example.bedwars.gui.editor.EditorView;
 
 public final class BWMenuHolder implements InventoryHolder {
   public final AdminView view;
+  public final EditorView editorView; // non nul pour sous-vues éditeur
   public final String arenaId; // null sur ROOT ou vues globales
 
   public BWMenuHolder(AdminView view, String arenaId) {
     this.view = view;
+    this.editorView = null;
+    this.arenaId = arenaId;
+  }
+
+  public BWMenuHolder(EditorView editor, String arenaId) {
+    this.view = AdminView.ARENA_EDITOR;
+    this.editorView = editor;
     this.arenaId = arenaId;
   }
 

--- a/src/main/java/com/example/bedwars/gui/MenuManager.java
+++ b/src/main/java/com/example/bedwars/gui/MenuManager.java
@@ -2,6 +2,7 @@ package com.example.bedwars.gui;
 
 import com.example.bedwars.BedwarsPlugin;
 import com.example.bedwars.gui.placeholders.*;
+import com.example.bedwars.gui.editor.*;
 import org.bukkit.entity.Player;
 
 public final class MenuManager {
@@ -15,6 +16,10 @@ public final class MenuManager {
   private final ResetMenu reset;
   private final DiagnosticsMenu diag;
   private final InfoMenu info;
+  private final ArenaEditorMenu editor;
+  private final TeamEditorMenu teamEditor;
+  private final GeneratorsEditorMenu genEditor;
+  private final NpcEditorMenu npcEditor;
 
   public MenuManager(BedwarsPlugin plugin) {
     this.plugin = plugin;
@@ -27,6 +32,10 @@ public final class MenuManager {
     this.reset = new ResetMenu(plugin);
     this.diag = new DiagnosticsMenu(plugin);
     this.info = new InfoMenu(plugin);
+    this.editor = new ArenaEditorMenu(plugin);
+    this.teamEditor = new TeamEditorMenu(plugin);
+    this.genEditor = new GeneratorsEditorMenu(plugin);
+    this.npcEditor = new NpcEditorMenu(plugin);
   }
 
   public void open(AdminView v, Player p, String arenaId) {
@@ -41,6 +50,15 @@ public final class MenuManager {
       case DIAGNOSTICS -> diag.open(p);
       case INFO -> info.open(p);
       default -> root.open(p);
+    }
+  }
+
+  public void openEditor(EditorView v, Player p, String arenaId) {
+    switch (v) {
+      case ARENA -> editor.open(p, arenaId);
+      case TEAM -> teamEditor.open(p, arenaId);
+      case GEN -> genEditor.open(p, arenaId);
+      case NPC -> npcEditor.open(p, arenaId);
     }
   }
 }

--- a/src/main/java/com/example/bedwars/gui/editor/ArenaEditorMenu.java
+++ b/src/main/java/com/example/bedwars/gui/editor/ArenaEditorMenu.java
@@ -1,0 +1,55 @@
+package com.example.bedwars.gui.editor;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public final class ArenaEditorMenu {
+  private final BedwarsPlugin plugin;
+  public static final int SLOT_LOBBY = 10;
+  public static final int SLOT_TEAMS = 12;
+  public static final int SLOT_NPC = 14;
+  public static final int SLOT_GENS = 16;
+  public static final int SLOT_SAVE = 28;
+  public static final int SLOT_RELOAD = 30;
+  public static final int SLOT_DELETE = 32;
+  public static final int SLOT_BACK = 49;
+
+  public ArenaEditorMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p, String arenaId){
+    Arena a = plugin.arenas().get(arenaId).orElseThrow();
+    String title = plugin.messages().get("editor.title").replace("{arena}", arenaId);
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(EditorView.ARENA, arenaId), 54, title);
+    inv.setItem(SLOT_LOBBY, icon(Material.PAPER, "Set Lobby", a.lobby()!=null));
+    inv.setItem(SLOT_TEAMS, icon(Material.WHITE_WOOL, "Équipes", false));
+    inv.setItem(SLOT_NPC, icon(Material.EMERALD, "PNJ", !a.npcs().isEmpty()));
+    inv.setItem(SLOT_GENS, icon(Material.HOPPER, "Générateurs", !a.generators().isEmpty()));
+    inv.setItem(SLOT_SAVE, icon(Material.ANVIL, "Sauver", false));
+    inv.setItem(SLOT_RELOAD, icon(Material.BOOK, "Recharger", false));
+    inv.setItem(SLOT_DELETE, icon(Material.BARRIER, "Supprimer", false));
+    inv.setItem(SLOT_BACK, icon(Material.COMPASS, "Retour", false));
+    p.openInventory(inv);
+  }
+
+  private ItemStack icon(Material mat, String name, boolean glint){
+    ItemStack it = new ItemStack(mat);
+    ItemMeta im = it.getItemMeta();
+    if(im != null){
+      im.setDisplayName(name);
+      if(glint){
+        im.addEnchant(org.bukkit.enchantments.Enchantment.INFINITY,1,true);
+        im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+      }
+      it.setItemMeta(im);
+    }
+    return it;
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/editor/EditorView.java
+++ b/src/main/java/com/example/bedwars/gui/editor/EditorView.java
@@ -1,0 +1,8 @@
+package com.example.bedwars.gui.editor;
+
+public enum EditorView {
+  ARENA,
+  TEAM,
+  GEN,
+  NPC
+}

--- a/src/main/java/com/example/bedwars/gui/editor/GeneratorsEditorMenu.java
+++ b/src/main/java/com/example/bedwars/gui/editor/GeneratorsEditorMenu.java
@@ -1,0 +1,47 @@
+package com.example.bedwars.gui.editor;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public final class GeneratorsEditorMenu {
+  private final BedwarsPlugin plugin;
+  public static final int SLOT_IRON = 10;
+  public static final int SLOT_GOLD = 12;
+  public static final int SLOT_DIAMOND = 14;
+  public static final int SLOT_EMERALD = 16;
+  public static final int SLOT_BACK = 49;
+
+  public GeneratorsEditorMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p, String arenaId){
+    String title = plugin.messages().get("editor.gens-title").replace("{arena}", arenaId);
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(EditorView.GEN, arenaId), 54, title);
+    inv.setItem(SLOT_IRON, icon(Material.IRON_INGOT, "Fer", false));
+    inv.setItem(SLOT_GOLD, icon(Material.GOLD_INGOT, "Or", false));
+    inv.setItem(SLOT_DIAMOND, icon(Material.DIAMOND, "Diamant", false));
+    inv.setItem(SLOT_EMERALD, icon(Material.EMERALD, "Émeraude", false));
+    inv.setItem(SLOT_BACK, icon(Material.COMPASS, "Retour", false));
+    p.openInventory(inv);
+  }
+
+  private ItemStack icon(Material mat, String name, boolean glint){
+    ItemStack it = new ItemStack(mat);
+    ItemMeta im = it.getItemMeta();
+    if(im != null){
+      im.setDisplayName(name);
+      if(glint){
+        im.addEnchant(org.bukkit.enchantments.Enchantment.INFINITY,1,true);
+        im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+      }
+      it.setItemMeta(im);
+    }
+    return it;
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/editor/NpcEditorMenu.java
+++ b/src/main/java/com/example/bedwars/gui/editor/NpcEditorMenu.java
@@ -1,0 +1,43 @@
+package com.example.bedwars.gui.editor;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public final class NpcEditorMenu {
+  private final BedwarsPlugin plugin;
+  public static final int SLOT_ADD_ITEM = 11;
+  public static final int SLOT_ADD_UPGRADE = 15;
+  public static final int SLOT_BACK = 49;
+
+  public NpcEditorMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p, String arenaId){
+    String title = plugin.messages().get("editor.npc-title").replace("{arena}", arenaId);
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(EditorView.NPC, arenaId), 54, title);
+    inv.setItem(SLOT_ADD_ITEM, icon(Material.CHEST, "Ajouter PNJ Objets", false));
+    inv.setItem(SLOT_ADD_UPGRADE, icon(Material.ANVIL, "Ajouter PNJ Améliorations", false));
+    inv.setItem(SLOT_BACK, icon(Material.COMPASS, "Retour", false));
+    p.openInventory(inv);
+  }
+
+  private ItemStack icon(Material mat, String name, boolean glint){
+    ItemStack it = new ItemStack(mat);
+    ItemMeta im = it.getItemMeta();
+    if(im != null){
+      im.setDisplayName(name);
+      if(glint){
+        im.addEnchant(org.bukkit.enchantments.Enchantment.INFINITY,1,true);
+        im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+      }
+      it.setItemMeta(im);
+    }
+    return it;
+  }
+}

--- a/src/main/java/com/example/bedwars/gui/editor/TeamEditorMenu.java
+++ b/src/main/java/com/example/bedwars/gui/editor/TeamEditorMenu.java
@@ -1,0 +1,55 @@
+package com.example.bedwars.gui.editor;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.TeamColor;
+import com.example.bedwars.gui.BWMenuHolder;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+public final class TeamEditorMenu {
+  private final BedwarsPlugin plugin;
+  private static final int BASE_TEAM = 10;
+  private static final int BASE_SPAWN = 19;
+  private static final int BASE_BED = 28;
+  public static final int SLOT_BACK = 49;
+
+  public TeamEditorMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p, String arenaId){
+    Arena a = plugin.arenas().get(arenaId).orElseThrow();
+    String title = plugin.messages().get("editor.team-title").replace("{arena}", arenaId);
+    Inventory inv = Bukkit.createInventory(new BWMenuHolder(EditorView.TEAM, arenaId), 54, title);
+    TeamColor[] colors = TeamColor.values();
+    for(int i=0;i<colors.length;i++){
+      TeamColor c = colors[i];
+      boolean enabled = a.enabledTeams().contains(c);
+      inv.setItem(BASE_TEAM+i, icon(c.wool, c.display, enabled));
+      boolean hasSpawn = a.team(c).spawn()!=null;
+      inv.setItem(BASE_SPAWN+i, icon(Material.COMPASS, "Spawn "+c.display, hasSpawn));
+      boolean hasBed = a.team(c).bedBlock()!=null;
+      inv.setItem(BASE_BED+i, icon(Material.RED_BED, "Lit "+c.display, hasBed));
+    }
+    inv.setItem(SLOT_BACK, icon(Material.COMPASS, "Retour", false));
+    p.openInventory(inv);
+  }
+
+  private ItemStack icon(Material mat, String name, boolean glint){
+    ItemStack it = new ItemStack(mat);
+    ItemMeta im = it.getItemMeta();
+    if(im != null){
+      im.setDisplayName(name);
+      if(glint){
+        im.addEnchant(org.bukkit.enchantments.Enchantment.INFINITY,1,true);
+        im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+      }
+      it.setItemMeta(im);
+    }
+    return it;
+  }
+}

--- a/src/main/java/com/example/bedwars/listeners/EditorListener.java
+++ b/src/main/java/com/example/bedwars/listeners/EditorListener.java
@@ -1,0 +1,145 @@
+package com.example.bedwars.listeners;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.TeamColor;
+import com.example.bedwars.gen.GeneratorType;
+import com.example.bedwars.gui.BWMenuHolder;
+import com.example.bedwars.gui.AdminView;
+import com.example.bedwars.gui.editor.*;
+import com.example.bedwars.ops.Keys;
+import com.example.bedwars.shop.NpcType;
+import org.bukkit.FluidCollisionMode;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.Bed;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.persistence.PersistentDataType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+
+public final class EditorListener implements Listener {
+  private final BedwarsPlugin plugin;
+
+  public EditorListener(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  @EventHandler
+  public void onClick(InventoryClickEvent e){
+    Inventory top = e.getView().getTopInventory();
+    if(!(top.getHolder() instanceof BWMenuHolder holder)) return;
+    if(holder.editorView == null) return;
+    e.setCancelled(true);
+    if(!(e.getWhoClicked() instanceof Player p)) return;
+    if(!p.hasPermission("bedwars.admin")) { p.sendMessage(plugin.messages().get("admin.no-perm")); return; }
+    if(e.getClickedInventory() != top) return;
+    int slot = e.getRawSlot();
+    String id = holder.arenaId;
+    switch(holder.editorView){
+      case ARENA -> handleArena(slot, p, id);
+      case TEAM -> handleTeam(slot, p, id);
+      case GEN -> handleGen(slot, p, id);
+      case NPC -> handleNpc(slot, p, id);
+    }
+    if(e.getClick().isShiftClick() || e.getClick()==ClickType.NUMBER_KEY || e.getClick()==ClickType.SWAP_OFFHAND){
+      e.setCancelled(true);
+    }
+  }
+
+  private void handleArena(int slot, Player p, String id){
+    switch(slot){
+      case ArenaEditorMenu.SLOT_LOBBY -> {
+        plugin.arenas().setLobby(id, p.getLocation());
+        p.sendMessage(plugin.messages().get("editor.set-lobby"));
+        plugin.menus().openEditor(EditorView.ARENA, p, id);
+      }
+      case ArenaEditorMenu.SLOT_TEAMS -> plugin.menus().openEditor(EditorView.TEAM, p, id);
+      case ArenaEditorMenu.SLOT_NPC -> plugin.menus().openEditor(EditorView.NPC, p, id);
+      case ArenaEditorMenu.SLOT_GENS -> plugin.menus().openEditor(EditorView.GEN, p, id);
+      case ArenaEditorMenu.SLOT_SAVE -> { plugin.arenas().save(id); p.sendMessage(plugin.messages().get("editor.saved")); }
+      case ArenaEditorMenu.SLOT_RELOAD -> { plugin.arenas().load(id); plugin.menus().openEditor(EditorView.ARENA, p, id); p.sendMessage(plugin.messages().get("editor.reloaded")); }
+      case ArenaEditorMenu.SLOT_DELETE -> { plugin.prompts().start(p, com.example.bedwars.setup.EditorActions.CONFIRM_DELETE, id, 20*30); p.closeInventory(); }
+      case ArenaEditorMenu.SLOT_BACK -> plugin.menus().open(AdminView.ARENAS, p, null);
+    }
+  }
+
+  private void handleTeam(int slot, Player p, String id){
+    TeamColor[] colors = TeamColor.values();
+    if(slot >=10 && slot <18){
+      TeamColor c = colors[slot-10];
+      Arena a = plugin.arenas().get(id).orElseThrow();
+      if(a.enabledTeams().contains(c)) plugin.arenas().disableTeam(id, c); else plugin.arenas().enableTeam(id, c);
+      plugin.menus().openEditor(EditorView.TEAM, p, id);
+      return;
+    }
+    if(slot >=19 && slot <27){
+      TeamColor c = colors[slot-19];
+      plugin.arenas().setTeamSpawn(id, c, p.getLocation());
+      p.sendMessage(plugin.messages().get("editor.set-spawn").replace("{team}", c.display));
+      plugin.menus().openEditor(EditorView.TEAM, p, id);
+      return;
+    }
+    if(slot >=28 && slot <36){
+      TeamColor c = colors[slot-28];
+      Block b = p.getTargetBlockExact(6, FluidCollisionMode.NEVER);
+      if(b == null || !(b.getBlockData() instanceof Bed bed) || bed.getPart() != Bed.Part.HEAD){
+        p.sendMessage(plugin.messages().get("editor.not-looking-bed"));
+        return;
+      }
+      plugin.arenas().setTeamBed(id, c, b.getLocation());
+      p.sendMessage(plugin.messages().get("editor.set-bed").replace("{team}", c.display));
+      plugin.menus().openEditor(EditorView.TEAM, p, id);
+      return;
+    }
+    if(slot == TeamEditorMenu.SLOT_BACK){ plugin.menus().openEditor(EditorView.ARENA, p, id); }
+  }
+
+  private void handleNpc(int slot, Player p, String id){
+    if(slot == NpcEditorMenu.SLOT_ADD_ITEM){
+      LivingEntity e = (LivingEntity)p.getWorld().spawnEntity(p.getLocation(), EntityType.VILLAGER);
+      e.setAI(false); e.setInvulnerable(true); e.setCollidable(false); e.setRemoveWhenFarAway(false);
+      e.getPersistentDataContainer().set(Keys.ARENA_ID, PersistentDataType.STRING, id);
+      e.getPersistentDataContainer().set(Keys.NPC_KIND, PersistentDataType.STRING, "item");
+      e.customName(Component.text("Objets", NamedTextColor.GREEN));
+      e.setCustomNameVisible(true);
+      plugin.arenas().addNpc(id, NpcType.ITEM, e.getLocation());
+      p.sendMessage(plugin.messages().get("editor.npc-item-added"));
+    } else if(slot == NpcEditorMenu.SLOT_ADD_UPGRADE){
+      LivingEntity e = (LivingEntity)p.getWorld().spawnEntity(p.getLocation(), EntityType.VILLAGER);
+      e.setAI(false); e.setInvulnerable(true); e.setCollidable(false); e.setRemoveWhenFarAway(false);
+      e.getPersistentDataContainer().set(Keys.ARENA_ID, PersistentDataType.STRING, id);
+      e.getPersistentDataContainer().set(Keys.NPC_KIND, PersistentDataType.STRING, "upgrade");
+      e.customName(Component.text("Améliorations", NamedTextColor.AQUA));
+      e.setCustomNameVisible(true);
+      plugin.arenas().addNpc(id, NpcType.UPGRADE, e.getLocation());
+      p.sendMessage(plugin.messages().get("editor.npc-upgrade-added"));
+    } else if(slot == NpcEditorMenu.SLOT_BACK){
+      plugin.menus().openEditor(EditorView.ARENA, p, id);
+    }
+  }
+
+  private void handleGen(int slot, Player p, String id){
+    GeneratorType type = null;
+    if(slot == GeneratorsEditorMenu.SLOT_IRON) type = GeneratorType.IRON;
+    else if(slot == GeneratorsEditorMenu.SLOT_GOLD) type = GeneratorType.GOLD;
+    else if(slot == GeneratorsEditorMenu.SLOT_DIAMOND) type = GeneratorType.DIAMOND;
+    else if(slot == GeneratorsEditorMenu.SLOT_EMERALD) type = GeneratorType.EMERALD;
+    else if(slot == GeneratorsEditorMenu.SLOT_BACK) { plugin.menus().openEditor(EditorView.ARENA, p, id); return; }
+    if(type != null){
+      var g = plugin.arenas().addGenerator(id, type, p.getLocation(), 1);
+      ArmorStand as = (ArmorStand)p.getWorld().spawnEntity(p.getLocation(), EntityType.ARMOR_STAND);
+      as.setInvisible(true); as.setMarker(true); as.setCustomNameVisible(true);
+      as.customName(Component.text(type.name()));
+      as.getPersistentDataContainer().set(Keys.ARENA_ID, PersistentDataType.STRING, id);
+      as.getPersistentDataContainer().set(Keys.GEN_MARKER, PersistentDataType.STRING, "1");
+      as.getPersistentDataContainer().set(Keys.GEN_KIND, PersistentDataType.STRING, type.name());
+      p.sendMessage(plugin.messages().get("editor.gen-added").replace("{type}", type.name()).replace("{tier}", String.valueOf(g.tier())));
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/listeners/MenuListener.java
+++ b/src/main/java/com/example/bedwars/listeners/MenuListener.java
@@ -8,6 +8,7 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
+import com.example.bedwars.setup.EditorActions;
 
 public final class MenuListener implements Listener {
   private final BedwarsPlugin plugin;
@@ -31,7 +32,10 @@ public final class MenuListener implements Listener {
     if (holder.view == AdminView.ROOT) {
       switch (slot) {
         case RootMenu.SLOT_ARENAS    -> plugin.menus().open(AdminView.ARENAS, p, null);
-        case RootMenu.SLOT_CREATE    -> plugin.menus().open(AdminView.ARENAS, p, null); // Étape 4: lancera le wizard
+        case RootMenu.SLOT_CREATE    -> {
+          p.closeInventory();
+          plugin.prompts().start(p, EditorActions.CREATE_ARENA_ID, null, 20*30);
+        }
         case RootMenu.SLOT_RULES     -> plugin.menus().open(AdminView.RULES_EVENTS, p, null);
         case RootMenu.SLOT_SHOPS     -> plugin.menus().open(AdminView.NPC_SHOPS, p, null);
         case RootMenu.SLOT_GENS      -> plugin.menus().open(AdminView.GENERATORS, p, null);

--- a/src/main/java/com/example/bedwars/setup/EditorActions.java
+++ b/src/main/java/com/example/bedwars/setup/EditorActions.java
@@ -1,0 +1,6 @@
+package com.example.bedwars.setup;
+
+public enum EditorActions {
+  CREATE_ARENA_ID,
+  CONFIRM_DELETE
+}

--- a/src/main/java/com/example/bedwars/setup/PendingAction.java
+++ b/src/main/java/com/example/bedwars/setup/PendingAction.java
@@ -1,0 +1,3 @@
+package com.example.bedwars.setup;
+
+public record PendingAction(EditorActions action, Object payload, long expiresAt) {}

--- a/src/main/java/com/example/bedwars/setup/PromptService.java
+++ b/src/main/java/com/example/bedwars/setup/PromptService.java
@@ -1,0 +1,93 @@
+package com.example.bedwars.setup;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.WorldRef;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+public final class PromptService implements Listener {
+  private static final Pattern ID = Pattern.compile("^[a-z0-9_-]{3,32}$");
+  private final BedwarsPlugin plugin;
+  private final Map<UUID, PendingAction> pending = new ConcurrentHashMap<>();
+
+  public PromptService(BedwarsPlugin plugin){
+    this.plugin = plugin;
+  }
+
+  public void start(Player p, EditorActions action, Object payload, long timeoutTicks) {
+    PendingAction pa = new PendingAction(action, payload, System.currentTimeMillis()+timeoutTicks*50);
+    pending.put(p.getUniqueId(), pa);
+    if(action == EditorActions.CREATE_ARENA_ID){
+      p.sendMessage(plugin.messages().get("editor.create-id"));
+    } else if(action == EditorActions.CONFIRM_DELETE && payload instanceof String id){
+      p.sendMessage(plugin.messages().get("editor.confirm-delete").replace("{arena}", id));
+    }
+    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+      PendingAction removed = pending.remove(p.getUniqueId());
+      if(removed != null){
+        p.sendMessage(plugin.messages().get("editor.timeout"));
+      }
+    }, timeoutTicks);
+  }
+
+  @EventHandler
+  public void onChat(AsyncPlayerChatEvent e){
+    PendingAction pa = pending.get(e.getPlayer().getUniqueId());
+    if(pa == null) return;
+    e.setCancelled(true);
+    Bukkit.getScheduler().runTask(plugin, () -> handle(e.getPlayer(), pa, e.getMessage()));
+  }
+
+  private void handle(Player p, PendingAction pa, String msg){
+    if(System.currentTimeMillis() > pa.expiresAt()){ pending.remove(p.getUniqueId()); return; }
+    switch(pa.action()){
+      case CREATE_ARENA_ID -> {
+        int attempts = pa.payload() instanceof Integer i ? i : 0;
+        if(!ID.matcher(msg).matches()){
+          if(attempts >= 1){
+            p.sendMessage(plugin.messages().get("editor.create-id-invalid"));
+            pending.remove(p.getUniqueId());
+            return;
+          }
+          p.sendMessage(plugin.messages().get("editor.create-id-invalid"));
+          start(p, EditorActions.CREATE_ARENA_ID, attempts+1, 20*30);
+          return;
+        }
+        if(plugin.arenas().get(msg).isPresent()){
+          if(attempts >= 1){
+            p.sendMessage(plugin.messages().get("editor.create-id-exists"));
+            pending.remove(p.getUniqueId());
+            return;
+          }
+          p.sendMessage(plugin.messages().get("editor.create-id-exists"));
+          start(p, EditorActions.CREATE_ARENA_ID, attempts+1, 20*30);
+          return;
+        }
+        pending.remove(p.getUniqueId());
+        Arena a = plugin.arenas().create(msg, new WorldRef(p.getWorld().getName()));
+        p.sendMessage(plugin.messages().get("editor.created").replace("{arena}", a.id()));
+        plugin.menus().openEditor(com.example.bedwars.gui.editor.EditorView.ARENA, p, a.id());
+      }
+      case CONFIRM_DELETE -> {
+        pending.remove(p.getUniqueId());
+        if(!"CONFIRM".equalsIgnoreCase(msg)) return;
+        if(pa.payload() instanceof String id){
+          plugin.arenas().delete(id);
+          p.sendMessage(plugin.messages().get("editor.deleted").replace("{arena}", id));
+        }
+      }
+    }
+  }
+
+  public void cancel(Player p){ pending.remove(p.getUniqueId()); }
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -52,3 +52,29 @@ admin:
 
   placeholders:
     wip: "&7Cette vue sera complétée à l'étape suivante."
+
+editor:
+  title: "&8Éditeur d'arène &7({arena})"
+  team-title: "&8Équipes &7({arena})"
+  gens-title: "&8Générateurs &7({arena})"
+  npc-title:  "&8PNJ &7({arena})"
+
+  create-id: "&eEntre l'ID de la nouvelle arène (a-z,0-9,_,-):"
+  create-id-exists: "&cID déjà utilisé."
+  create-id-invalid: "&cID invalide."
+  created: "&aArène &e{arena}&a créée."
+
+  set-lobby: "&aLobby défini."
+  set-spawn: "&aSpawn &e{team}&a défini."
+  set-bed: "&aLit &e{team}&a défini."
+  not-looking-bed: "&cRegardez un bloc de lit (tête) à portée."
+
+  npc-item-added: "&aPNJ Boutique Objets ajouté."
+  npc-upgrade-added: "&aPNJ Améliorations ajouté."
+  gen-added: "&aGénérateur &e{type}&a ajouté (Tier {tier})."
+
+  saved: "&aArène sauvegardée."
+  reloaded: "&aArène rechargée."
+  deleted: "&aArène supprimée."
+  confirm-delete: "&cTapez &eCONFIRM &cpour supprimer l'arène &e{arena}&c (30s)."
+  timeout: "&cPrompt expiré."


### PR DESCRIPTION
## Summary
- add chat-driven arena creation prompt and delete confirmation
- introduce arena editor menus for lobby, teams, NPCs and generators
- wire editor listeners and services into plugin lifecycle

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bcf3697908329aa322df766a8eee8