### PR TITLE
fix: purge Adventure and repair arena editor

### DIFF
--- a/src/main/java/com/example/bedwars/listeners/EditorListener.java
+++ b/src/main/java/com/example/bedwars/listeners/EditorListener.java
@@ -9,21 +9,22 @@ import com.example.bedwars.gui.AdminView;
 import com.example.bedwars.gui.editor.*;
 import com.example.bedwars.ops.Keys;
 import com.example.bedwars.shop.NpcType;
+import org.bukkit.ChatColor;
 import org.bukkit.FluidCollisionMode;
+import org.bukkit.Location;
 import org.bukkit.block.Block;
-import org.bukkit.block.data.Bed;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Bed;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.persistence.PersistentDataType;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
+import java.util.Map;
 
 public final class EditorListener implements Listener {
   private final BedwarsPlugin plugin;
@@ -34,10 +35,10 @@ public final class EditorListener implements Listener {
   public void onClick(InventoryClickEvent e){
     Inventory top = e.getView().getTopInventory();
     if(!(top.getHolder() instanceof BWMenuHolder holder)) return;
-    if(holder.editorView == null) return;
     e.setCancelled(true);
     if(!(e.getWhoClicked() instanceof Player p)) return;
     if(!p.hasPermission("bedwars.admin")) { p.sendMessage(plugin.messages().get("admin.no-perm")); return; }
+    if(holder.view != AdminView.ARENA_EDITOR || holder.editorView == null) return;
     if(e.getClickedInventory() != top) return;
     int slot = e.getRawSlot();
     String id = holder.arenaId;
@@ -47,14 +48,12 @@ public final class EditorListener implements Listener {
       case GEN -> handleGen(slot, p, id);
       case NPC -> handleNpc(slot, p, id);
     }
-    if(e.getClick().isShiftClick() || e.getClick()==ClickType.NUMBER_KEY || e.getClick()==ClickType.SWAP_OFFHAND){
-      e.setCancelled(true);
-    }
   }
 
   private void handleArena(int slot, Player p, String id){
     switch(slot){
       case ArenaEditorMenu.SLOT_LOBBY -> {
+        if(!ensureWorld(p, id)) return;
         plugin.arenas().setLobby(id, p.getLocation());
         p.sendMessage(plugin.messages().get("editor.set-lobby"));
         plugin.menus().openEditor(EditorView.ARENA, p, id);
@@ -62,9 +61,19 @@ public final class EditorListener implements Listener {
       case ArenaEditorMenu.SLOT_TEAMS -> plugin.menus().openEditor(EditorView.TEAM, p, id);
       case ArenaEditorMenu.SLOT_NPC -> plugin.menus().openEditor(EditorView.NPC, p, id);
       case ArenaEditorMenu.SLOT_GENS -> plugin.menus().openEditor(EditorView.GEN, p, id);
-      case ArenaEditorMenu.SLOT_SAVE -> { plugin.arenas().save(id); p.sendMessage(plugin.messages().get("editor.saved")); }
-      case ArenaEditorMenu.SLOT_RELOAD -> { plugin.arenas().load(id); plugin.menus().openEditor(EditorView.ARENA, p, id); p.sendMessage(plugin.messages().get("editor.reloaded")); }
-      case ArenaEditorMenu.SLOT_DELETE -> { plugin.prompts().start(p, com.example.bedwars.setup.EditorActions.CONFIRM_DELETE, id, 20*30); p.closeInventory(); }
+      case ArenaEditorMenu.SLOT_SAVE -> {
+        plugin.arenas().save(id);
+        p.sendMessage(plugin.messages().get("editor.saved"));
+      }
+      case ArenaEditorMenu.SLOT_RELOAD -> {
+        plugin.arenas().load(id);
+        plugin.menus().openEditor(EditorView.ARENA, p, id);
+        p.sendMessage(plugin.messages().get("editor.reloaded"));
+      }
+      case ArenaEditorMenu.SLOT_DELETE -> {
+        plugin.prompts().start(p, com.example.bedwars.setup.EditorActions.CONFIRM_DELETE, id, 20*30);
+        p.closeInventory();
+      }
       case ArenaEditorMenu.SLOT_BACK -> plugin.menus().open(AdminView.ARENAS, p, null);
     }
   }
@@ -80,20 +89,22 @@ public final class EditorListener implements Listener {
     }
     if(slot >=19 && slot <27){
       TeamColor c = colors[slot-19];
+      if(!ensureWorld(p, id)) return;
       plugin.arenas().setTeamSpawn(id, c, p.getLocation());
-      p.sendMessage(plugin.messages().get("editor.set-spawn").replace("{team}", c.display));
+      p.sendMessage(plugin.messages().format("editor.set-spawn", Map.of("team", c.display)));
       plugin.menus().openEditor(EditorView.TEAM, p, id);
       return;
     }
     if(slot >=28 && slot <36){
       TeamColor c = colors[slot-28];
-      Block b = p.getTargetBlockExact(6, FluidCollisionMode.NEVER);
-      if(b == null || !(b.getBlockData() instanceof Bed bed) || bed.getPart() != Bed.Part.HEAD){
+      if(!ensureWorld(p, id)) return;
+      Location head = findBedHead(p);
+      if(head == null){
         p.sendMessage(plugin.messages().get("editor.not-looking-bed"));
         return;
       }
-      plugin.arenas().setTeamBed(id, c, b.getLocation());
-      p.sendMessage(plugin.messages().get("editor.set-bed").replace("{team}", c.display));
+      plugin.arenas().setTeamBed(id, c, head);
+      p.sendMessage(plugin.messages().format("editor.set-bed", Map.of("team", c.display)));
       plugin.menus().openEditor(EditorView.TEAM, p, id);
       return;
     }
@@ -102,20 +113,22 @@ public final class EditorListener implements Listener {
 
   private void handleNpc(int slot, Player p, String id){
     if(slot == NpcEditorMenu.SLOT_ADD_ITEM){
+      if(!ensureWorld(p, id)) return;
       LivingEntity e = (LivingEntity)p.getWorld().spawnEntity(p.getLocation(), EntityType.VILLAGER);
       e.setAI(false); e.setInvulnerable(true); e.setCollidable(false); e.setRemoveWhenFarAway(false);
       e.getPersistentDataContainer().set(Keys.ARENA_ID, PersistentDataType.STRING, id);
       e.getPersistentDataContainer().set(Keys.NPC_KIND, PersistentDataType.STRING, "item");
-      e.customName(Component.text("Objets", NamedTextColor.GREEN));
+      e.setCustomName(ChatColor.GREEN + "Objets");
       e.setCustomNameVisible(true);
       plugin.arenas().addNpc(id, NpcType.ITEM, e.getLocation());
       p.sendMessage(plugin.messages().get("editor.npc-item-added"));
     } else if(slot == NpcEditorMenu.SLOT_ADD_UPGRADE){
+      if(!ensureWorld(p, id)) return;
       LivingEntity e = (LivingEntity)p.getWorld().spawnEntity(p.getLocation(), EntityType.VILLAGER);
       e.setAI(false); e.setInvulnerable(true); e.setCollidable(false); e.setRemoveWhenFarAway(false);
       e.getPersistentDataContainer().set(Keys.ARENA_ID, PersistentDataType.STRING, id);
       e.getPersistentDataContainer().set(Keys.NPC_KIND, PersistentDataType.STRING, "upgrade");
-      e.customName(Component.text("Améliorations", NamedTextColor.AQUA));
+      e.setCustomName(ChatColor.AQUA + "Améliorations");
       e.setCustomNameVisible(true);
       plugin.arenas().addNpc(id, NpcType.UPGRADE, e.getLocation());
       p.sendMessage(plugin.messages().get("editor.npc-upgrade-added"));
@@ -132,14 +145,40 @@ public final class EditorListener implements Listener {
     else if(slot == GeneratorsEditorMenu.SLOT_EMERALD) type = GeneratorType.EMERALD;
     else if(slot == GeneratorsEditorMenu.SLOT_BACK) { plugin.menus().openEditor(EditorView.ARENA, p, id); return; }
     if(type != null){
+      if(!ensureWorld(p, id)) return;
       var g = plugin.arenas().addGenerator(id, type, p.getLocation(), 1);
       ArmorStand as = (ArmorStand)p.getWorld().spawnEntity(p.getLocation(), EntityType.ARMOR_STAND);
       as.setInvisible(true); as.setMarker(true); as.setCustomNameVisible(true);
-      as.customName(Component.text(type.name()));
+      as.setCustomName(type.name());
       as.getPersistentDataContainer().set(Keys.ARENA_ID, PersistentDataType.STRING, id);
       as.getPersistentDataContainer().set(Keys.GEN_MARKER, PersistentDataType.STRING, "1");
       as.getPersistentDataContainer().set(Keys.GEN_KIND, PersistentDataType.STRING, type.name());
-      p.sendMessage(plugin.messages().get("editor.gen-added").replace("{type}", type.name()).replace("{tier}", String.valueOf(g.tier())));
+      p.sendMessage(plugin.messages().format("editor.gen-added", Map.of("type", type.name(), "tier", String.valueOf(g.tier()))));
     }
+  }
+
+  private boolean ensureWorld(Player p, String id){
+    String arenaWorld = plugin.arenas().get(id).map(a -> a.world().name()).orElse(null);
+    if(arenaWorld == null) return false;
+    if(!p.getWorld().getName().equals(arenaWorld)){
+      p.sendMessage(plugin.messages().get("arena.world-required"));
+      return false;
+    }
+    return true;
+  }
+
+  private Location findBedHead(Player p){
+    Block target = p.getTargetBlockExact(6, FluidCollisionMode.NEVER);
+    if(target == null) return null;
+    BlockData data = target.getBlockData();
+    if(!(data instanceof Bed bed)) return null;
+    Block headBlock = target;
+    if(bed.getPart() != Bed.Part.HEAD){
+      org.bukkit.block.BlockFace facing = bed.getFacing();
+      headBlock = target.getRelative(facing);
+      BlockData d2 = headBlock.getBlockData();
+      if(!(d2 instanceof Bed b2) || b2.getPart() != Bed.Part.HEAD) return null;
+    }
+    return headBlock.getLocation();
   }
 }

--- a/src/main/java/com/example/bedwars/util/Messages.java
+++ b/src/main/java/com/example/bedwars/util/Messages.java
@@ -2,6 +2,7 @@ package com.example.bedwars.util;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -22,6 +23,14 @@ public final class Messages {
   public String get(String path) {
     String raw = cfg.getString(path, path);
     return ChatColor.translateAlternateColorCodes('&', raw);
+  }
+
+  public String format(String path, Map<String, ?> placeholders) {
+    String msg = get(path);
+    for (Map.Entry<String, ?> e : placeholders.entrySet()) {
+      msg = msg.replace("{" + e.getKey() + "}", String.valueOf(e.getValue()));
+    }
+    return msg;
   }
 
   public List<String> getList(String path) {


### PR DESCRIPTION
## Summary
- remove Adventure text usage from editor listener
- add world checks and robust bed head raycast for team bed setting
- add simple message formatting helper

## Testing
- `mvn -q -e package -DskipTests` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bd1b00b50832992d708be16fd5994