### PR TITLE
feat: add shop and upgrade menus

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -10,6 +10,10 @@ import com.example.bedwars.gui.MenuManager;
 import com.example.bedwars.listeners.MenuListener;
 import com.example.bedwars.listeners.EditorListener;
 import com.example.bedwars.setup.PromptService;
+import com.example.bedwars.shop.ShopConfig;
+import com.example.bedwars.shop.UpgradeService;
+import com.example.bedwars.shop.ShopListener;
+import com.example.bedwars.service.PlayerContextService;
 
 public final class BedwarsPlugin extends JavaPlugin {
 
@@ -18,6 +22,9 @@ public final class BedwarsPlugin extends JavaPlugin {
   private ArenaManager arenaManager;
   private MenuManager menuManager;
   private PromptService promptService;
+  private ShopConfig shopConfig;
+  private PlayerContextService contextService;
+  private UpgradeService upgradeService;
 
   @Override
   public void onEnable() {
@@ -28,6 +35,9 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.arenaManager.loadAll();
     this.menuManager = new MenuManager(this);
     this.promptService = new PromptService(this);
+    this.shopConfig = new ShopConfig(this);
+    this.contextService = new PlayerContextService();
+    this.upgradeService = new UpgradeService(this, contextService);
 
     Objects.requireNonNull(getCommand("bw")).setExecutor(new BwCommand(this));
     Objects.requireNonNull(getCommand("bwadmin")).setExecutor(new BwAdminCommand(this));
@@ -35,6 +45,7 @@ public final class BedwarsPlugin extends JavaPlugin {
     getServer().getPluginManager().registerEvents(new MenuListener(this), this);
     getServer().getPluginManager().registerEvents(new EditorListener(this), this);
     getServer().getPluginManager().registerEvents(promptService, this);
+    getServer().getPluginManager().registerEvents(new ShopListener(this, contextService), this);
 
     getLogger().info("Bedwars loaded.");
   }
@@ -64,4 +75,8 @@ public final class BedwarsPlugin extends JavaPlugin {
   public PromptService prompts() {
     return promptService;
   }
+
+  public ShopConfig shopConfig() { return shopConfig; }
+  public PlayerContextService contexts() { return contextService; }
+  public UpgradeService upgrades() { return upgradeService; }
 }

--- a/src/main/java/com/example/bedwars/arena/TeamData.java
+++ b/src/main/java/com/example/bedwars/arena/TeamData.java
@@ -3,6 +3,8 @@ package com.example.bedwars.arena;
 import org.bukkit.Location;
 import java.util.Objects;
 
+import com.example.bedwars.shop.TeamUpgradesState;
+
 /**
  * Data describing a team in an arena.
  */
@@ -10,10 +12,12 @@ public final class TeamData {
   private Location spawn;        // null until defined
   private Location bedBlock;     // "head" block of the bed
   private int maxPlayers = 4;
+  private final TeamUpgradesState upgrades = new TeamUpgradesState();
 
   public Location spawn() { return spawn; }
   public Location bedBlock() { return bedBlock; }
   public int maxPlayers() { return maxPlayers; }
+  public TeamUpgradesState upgrades() { return upgrades; }
 
   public TeamData setSpawn(Location loc) { this.spawn = Objects.requireNonNull(loc); return this; }
   public TeamData setBedBlock(Location loc) { this.bedBlock = Objects.requireNonNull(loc); return this; }

--- a/src/main/java/com/example/bedwars/service/PlayerContextService.java
+++ b/src/main/java/com/example/bedwars/service/PlayerContextService.java
@@ -1,0 +1,41 @@
+package com.example.bedwars.service;
+
+import com.example.bedwars.arena.TeamColor;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import org.bukkit.entity.Player;
+
+/**
+ * Very small service storing the arena/team context of players.
+ * This is a placeholder until a full join/leave system is implemented.
+ */
+public final class PlayerContextService {
+
+  public static final class Context {
+    public final String arenaId;
+    public final TeamColor team;
+    public Context(String arenaId, TeamColor team) {
+      this.arenaId = arenaId; this.team = team;
+    }
+  }
+
+  private final Map<UUID, Context> contexts = new ConcurrentHashMap<>();
+
+  public void set(Player p, String arenaId, TeamColor team) {
+    contexts.put(p.getUniqueId(), new Context(arenaId, team));
+  }
+
+  public void remove(Player p) {
+    contexts.remove(p.getUniqueId());
+  }
+
+  public Optional<Context> get(Player p) {
+    return Optional.ofNullable(contexts.get(p.getUniqueId()));
+  }
+
+  public Optional<Context> get(UUID id) {
+    return Optional.ofNullable(contexts.get(id));
+  }
+}

--- a/src/main/java/com/example/bedwars/shop/PriceUtil.java
+++ b/src/main/java/com/example/bedwars/shop/PriceUtil.java
@@ -1,0 +1,56 @@
+package com.example.bedwars.shop;
+
+import java.util.Map;
+import java.util.StringJoiner;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Utility methods for costs in shops.
+ */
+public final class PriceUtil {
+  private PriceUtil() {}
+
+  public static boolean hasAndRemove(Player p, Map<Material,Integer> cost) {
+    Inventory inv = p.getInventory();
+    for (Map.Entry<Material,Integer> e : cost.entrySet()) {
+      int have = count(inv, e.getKey());
+      if (have < e.getValue()) return false;
+    }
+    // remove
+    for (Map.Entry<Material,Integer> e : cost.entrySet()) {
+      remove(inv, e.getKey(), e.getValue());
+    }
+    return true;
+  }
+
+  private static int count(Inventory inv, Material m) {
+    int total = 0;
+    for (ItemStack is : inv.getContents()) {
+      if (is != null && is.getType() == m) total += is.getAmount();
+    }
+    return total;
+  }
+
+  private static void remove(Inventory inv, Material m, int amount) {
+    for (int i = 0; i < inv.getSize(); i++) {
+      ItemStack is = inv.getItem(i);
+      if (is == null || is.getType() != m) continue;
+      int take = Math.min(amount, is.getAmount());
+      is.setAmount(is.getAmount() - take);
+      amount -= take;
+      if (amount <= 0) break;
+    }
+  }
+
+  public static String formatCost(Map<Material,Integer> cost) {
+    StringJoiner join = new StringJoiner(", ");
+    for (Map.Entry<Material,Integer> e : cost.entrySet()) {
+      String name = e.getKey().name().toLowerCase().replace('_', ' ');
+      join.add(e.getValue() + " " + name);
+    }
+    return join.toString();
+  }
+}

--- a/src/main/java/com/example/bedwars/shop/ShopCategory.java
+++ b/src/main/java/com/example/bedwars/shop/ShopCategory.java
@@ -1,0 +1,15 @@
+package com.example.bedwars.shop;
+
+/**
+ * Categories displayed in the item shop GUI.
+ */
+public enum ShopCategory {
+  QUICK_BUY,
+  BLOCKS,
+  MELEE,
+  ARMOR,
+  TOOLS,
+  RANGED,
+  POTIONS,
+  UTILITY
+}

--- a/src/main/java/com/example/bedwars/shop/ShopConfig.java
+++ b/src/main/java/com/example/bedwars/shop/ShopConfig.java
@@ -1,0 +1,159 @@
+package com.example.bedwars.shop;
+
+import com.example.bedwars.BedwarsPlugin;
+import java.io.File;
+import java.util.*;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.enchantments.Enchantment;
+
+/**
+ * Loads and provides access to shop configuration (items and upgrades).
+ */
+public final class ShopConfig {
+  private final BedwarsPlugin plugin;
+  private final Map<String, Material> currencies = new HashMap<>();
+  private final Map<ShopCategory, List<ShopItem>> items = new EnumMap<>(ShopCategory.class);
+
+  public static final class UpgradeDef {
+    public final List<Map<Material,Integer>> costs;
+    public final int maxLevel;
+    public final String name;
+    public UpgradeDef(List<Map<Material,Integer>> costs, int maxLevel, String name) {
+      this.costs = costs; this.maxLevel = maxLevel; this.name = name;
+    }
+  }
+  private final Map<UpgradeType, UpgradeDef> upgrades = new EnumMap<>(UpgradeType.class);
+
+  public static final class TrapDef {
+    public final Map<Material,Integer> cost;
+    public final String name;
+    public TrapDef(Map<Material,Integer> cost, String name) {
+      this.cost = cost; this.name = name;
+    }
+  }
+  private final Map<TrapType, TrapDef> traps = new EnumMap<>(TrapType.class);
+
+  public ShopConfig(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+    load();
+  }
+
+  private void load() {
+    File f = new File(plugin.getDataFolder(), "shop.yml");
+    if (!f.exists()) plugin.saveResource("shop.yml", false);
+    YamlConfiguration y = YamlConfiguration.loadConfiguration(f);
+
+    ConfigurationSection cur = y.getConfigurationSection("currencies");
+    if (cur != null) {
+      for (String k : cur.getKeys(false)) {
+        Material m = Material.matchMaterial(cur.getString(k, ""));
+        if (m != null) currencies.put(k.toUpperCase(Locale.ROOT), m);
+      }
+    }
+
+    ConfigurationSection itemsSec = y.getConfigurationSection("items");
+    if (itemsSec != null) {
+      for (String catKey : itemsSec.getKeys(false)) {
+        ShopCategory cat;
+        try { cat = ShopCategory.valueOf(catKey); } catch (IllegalArgumentException ex) { continue; }
+        List<ShopItem> list = new ArrayList<>();
+        for (Map<?,?> map : itemsSec.getMapList(catKey)) {
+          String id = String.valueOf(map.get("id"));
+          String matStr = String.valueOf(map.get("mat"));
+          boolean team = "WOOL_TEAM".equalsIgnoreCase(matStr);
+          Material mat = team ? Material.WHITE_WOOL : Material.matchMaterial(matStr);
+          int amount = map.containsKey("amount") ? ((Number)map.get("amount")).intValue() : 1;
+          Map<Material,Integer> price = parseCost(castMap(map.get("price")));
+          Map<Enchantment,Integer> ench = new HashMap<>();
+          Object enSec = map.get("enchants");
+          if (enSec instanceof Map<?,?> m2) {
+            for (var e : m2.entrySet()) {
+              Enchantment en = Enchantment.getByName(String.valueOf(e.getKey()));
+              if (en != null) ench.put(en, ((Number)e.getValue()).intValue());
+            }
+          }
+          String name = String.valueOf(map.get("name"));
+          list.add(new ShopItem(id, mat, amount, price, ench, name, team));
+        }
+        items.put(cat, list);
+      }
+    }
+
+    ConfigurationSection upSec = y.getConfigurationSection("upgrades");
+    if (upSec != null) {
+      for (String upKey : upSec.getKeys(false)) {
+        if (upKey.equalsIgnoreCase("TRAPS")) {
+          ConfigurationSection tSec = upSec.getConfigurationSection(upKey);
+          if (tSec != null) {
+            for (String t : tSec.getKeys(false)) {
+              TrapType tt;
+              try { tt = TrapType.valueOf(t.toUpperCase(Locale.ROOT)); } catch (Exception ex) { continue; }
+              ConfigurationSection sec = tSec.getConfigurationSection(t);
+              if (sec == null) continue;
+              Map<Material,Integer> cost = parseCost(sec.getConfigurationSection("cost"));
+              String name = sec.getString("name", t);
+              traps.put(tt, new TrapDef(cost, name));
+            }
+          }
+        } else {
+          UpgradeType type;
+          try { type = UpgradeType.valueOf(upKey); } catch (IllegalArgumentException ex) { continue; }
+          ConfigurationSection sec = upSec.getConfigurationSection(upKey);
+          if (sec == null) continue;
+          String name = sec.getString("name", upKey);
+          int max = sec.getInt("maxLevel", 0);
+          List<Map<Material,Integer>> costs = new ArrayList<>();
+          if (sec.isConfigurationSection("cost")) {
+            costs.add(parseCost(sec.getConfigurationSection("cost")));
+          }
+          for (Map<?,?> m : sec.getMapList("costs")) {
+            costs.add(parseCost(castMap(m)));
+          }
+          if (max == 0) max = costs.size();
+          upgrades.put(type, new UpgradeDef(costs, max, name));
+        }
+      }
+    }
+  }
+
+  private Map<Material,Integer> parseCost(ConfigurationSection sec) {
+    if (sec == null) return Map.of();
+    Map<Material,Integer> m = new EnumMap<>(Material.class);
+    for (String k : sec.getKeys(false)) {
+      Material mat = currencies.get(k.toUpperCase(Locale.ROOT));
+      if (mat != null) m.put(mat, sec.getInt(k));
+    }
+    return m;
+  }
+
+  private Map<Material,Integer> parseCost(Map<String,Object> raw) {
+    if (raw == null) return Map.of();
+    Map<Material,Integer> m = new EnumMap<>(Material.class);
+    for (var e : raw.entrySet()) {
+      Material mat = currencies.get(e.getKey().toUpperCase(Locale.ROOT));
+      if (mat != null) m.put(mat, ((Number)e.getValue()).intValue());
+    }
+    return m;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String,Object> castMap(Object o) {
+    if (o instanceof Map<?,?> map) {
+      Map<String,Object> res = new LinkedHashMap<>();
+      for (var e : map.entrySet()) {
+        res.put(String.valueOf(e.getKey()), e.getValue());
+      }
+      return res;
+    }
+    return new LinkedHashMap<>();
+  }
+
+  public List<ShopItem> items(ShopCategory cat) {
+    return items.getOrDefault(cat, List.of());
+  }
+
+  public UpgradeDef upgrade(UpgradeType t) { return upgrades.get(t); }
+  public TrapDef trap(TrapType t) { return traps.get(t); }
+}

--- a/src/main/java/com/example/bedwars/shop/ShopItem.java
+++ b/src/main/java/com/example/bedwars/shop/ShopItem.java
@@ -1,0 +1,58 @@
+package com.example.bedwars.shop;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+
+/**
+ * Definition of a purchasable item in the shop.
+ */
+public final class ShopItem {
+  public final String id;
+  public final Material mat;
+  public final int amount;
+  public final Map<Material,Integer> price;
+  public final Map<Enchantment,Integer> enchants;
+  public final String name;
+  public final boolean teamColored;
+
+  public ShopItem(String id, Material mat, int amount,
+                  Map<Material,Integer> price,
+                  Map<Enchantment,Integer> enchants,
+                  String name, boolean teamColored) {
+    this.id = id;
+    this.mat = mat;
+    this.amount = amount;
+    this.price = Collections.unmodifiableMap(new HashMap<>(price));
+    this.enchants = Collections.unmodifiableMap(new HashMap<>(enchants));
+    this.name = name;
+    this.teamColored = teamColored;
+  }
+
+  public static Builder builder(String id) { return new Builder(id); }
+
+  public static final class Builder {
+    private final String id;
+    private Material mat = Material.STONE;
+    private int amount = 1;
+    private final Map<Material,Integer> price = new HashMap<>();
+    private final Map<Enchantment,Integer> enchants = new HashMap<>();
+    private String name = id;
+    private boolean teamColored = false;
+
+    public Builder(String id) { this.id = id; }
+
+    public Builder mat(Material m) { this.mat = m; return this; }
+    public Builder amount(int a) { this.amount = a; return this; }
+    public Builder price(Material m, int qty) { this.price.put(m, qty); return this; }
+    public Builder enchant(Enchantment e, int lvl) { this.enchants.put(e, lvl); return this; }
+    public Builder name(String n) { this.name = n; return this; }
+    public Builder teamColored(boolean b) { this.teamColored = b; return this; }
+
+    public ShopItem build() {
+      return new ShopItem(id, mat, amount, price, enchants, name, teamColored);
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/shop/ShopListener.java
+++ b/src/main/java/com/example/bedwars/shop/ShopListener.java
@@ -1,0 +1,173 @@
+package com.example.bedwars.shop;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.TeamColor;
+import com.example.bedwars.arena.TeamData;
+import com.example.bedwars.ops.Keys;
+import com.example.bedwars.service.PlayerContextService;
+import com.example.bedwars.service.PlayerContextService.Context;
+import java.util.Map;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * Handles opening shop menus and processing clicks.
+ */
+public final class ShopListener implements Listener {
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService ctx;
+  private final ItemShopMenu itemMenu;
+  private final TeamUpgradesMenu upgradesMenu;
+
+  public ShopListener(BedwarsPlugin plugin, PlayerContextService ctx) {
+    this.plugin = plugin;
+    this.ctx = ctx;
+    this.itemMenu = new ItemShopMenu(plugin);
+    this.upgradesMenu = new TeamUpgradesMenu(plugin);
+  }
+
+  @EventHandler
+  public void onNpc(PlayerInteractEntityEvent e) {
+    if (!(e.getRightClicked() instanceof LivingEntity le)) return;
+    String arenaId = le.getPersistentDataContainer().get(Keys.ARENA_ID, PersistentDataType.STRING);
+    String kind = le.getPersistentDataContainer().get(Keys.NPC_KIND, PersistentDataType.STRING);
+    if (arenaId == null || kind == null) return;
+
+    Player p = e.getPlayer();
+    Context c = ctx.get(p).orElse(null);
+    if (c == null) { p.sendMessage(plugin.messages().get("shop.no-context")); return; }
+    if (kind.equalsIgnoreCase("item")) {
+      itemMenu.open(p, arenaId, c.team, ShopCategory.BLOCKS);
+    } else if (kind.equalsIgnoreCase("upgrade")) {
+      upgradesMenu.open(p, arenaId, c.team);
+    }
+    e.setCancelled(true);
+  }
+
+  @EventHandler
+  public void onClick(InventoryClickEvent e) {
+    Inventory top = e.getView().getTopInventory();
+    if (top.getHolder() instanceof ItemShopMenu.Holder ih) {
+      e.setCancelled(true);
+      if (!(e.getWhoClicked() instanceof Player p)) return;
+      int slot = e.getRawSlot();
+      if (slot < 9) {
+        ShopCategory[] cats = ShopCategory.values();
+        if (slot >= cats.length) return;
+        itemMenu.open(p, ih.arenaId, ih.team, cats[slot]);
+        return;
+      }
+      int index = slot - 9;
+      java.util.List<ShopItem> list = plugin.shopConfig().items(ih.cat);
+      if (index < 0 || index >= list.size()) return;
+      ShopItem si = list.get(index);
+      if (PriceUtil.hasAndRemove(p, si.price)) {
+        Material mat = si.teamColored ? ih.team.wool : si.mat;
+        ItemStack it = new ItemStack(mat, si.amount);
+        si.enchants.forEach((en,l)-> it.addEnchantment(en,l));
+        p.getInventory().addItem(it);
+        String name = ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', si.name.replace("{team}", ih.team.display)));
+        p.sendMessage(plugin.messages().format("shop.bought", Map.of("item", name)));
+      } else {
+        p.sendMessage(plugin.messages().format("shop.not-enough", Map.of("cost", PriceUtil.formatCost(si.price))));
+      }
+      return;
+    }
+
+    if (top.getHolder() instanceof TeamUpgradesMenu.Holder uh) {
+      e.setCancelled(true);
+      if (!(e.getWhoClicked() instanceof Player p)) return;
+      TeamData td = plugin.arenas().get(uh.arenaId).map(a->a.team(uh.team)).orElse(null);
+      if (td == null) return;
+      TeamUpgradesState st = td.upgrades();
+      int slot = e.getRawSlot();
+      if (slot == TeamUpgradesMenu.SLOT_SHARP) {
+        ShopConfig.UpgradeDef def = plugin.shopConfig().upgrade(UpgradeType.SHARPNESS);
+        if (st.sharpness()) { p.sendMessage(plugin.messages().get("shop.maxed")); return; }
+        Map<Material,Integer> cost = def.costs.get(0);
+        if (PriceUtil.hasAndRemove(p, cost)) {
+          st.setSharpness(true);
+          plugin.upgrades().applySharpness(uh.arenaId, uh.team);
+          p.sendMessage(plugin.messages().format("shop.applied", Map.of("name", def.name)));
+          upgradesMenu.open(p, uh.arenaId, uh.team);
+        } else {
+          p.sendMessage(plugin.messages().format("shop.not-enough", Map.of("cost", PriceUtil.formatCost(cost))));
+        }
+      } else if (slot == TeamUpgradesMenu.SLOT_PROT) {
+        ShopConfig.UpgradeDef def = plugin.shopConfig().upgrade(UpgradeType.PROTECTION);
+        int lvl = st.protection();
+        if (lvl >= def.maxLevel) { p.sendMessage(plugin.messages().get("shop.maxed")); return; }
+        Map<Material,Integer> cost = def.costs.get(lvl);
+        if (PriceUtil.hasAndRemove(p, cost)) {
+          st.setProtection(lvl+1);
+          plugin.upgrades().applyProtection(uh.arenaId, uh.team, st.protection());
+          String name = def.name.replace("{level}", String.valueOf(st.protection()));
+          p.sendMessage(plugin.messages().format("shop.applied", Map.of("name", name)));
+          upgradesMenu.open(p, uh.arenaId, uh.team);
+        } else {
+          p.sendMessage(plugin.messages().format("shop.not-enough", Map.of("cost", PriceUtil.formatCost(cost))));
+        }
+      } else if (slot == TeamUpgradesMenu.SLOT_HASTE) {
+        ShopConfig.UpgradeDef def = plugin.shopConfig().upgrade(UpgradeType.MANIC_MINER);
+        int lvl = st.manicMiner();
+        if (lvl >= def.maxLevel) { p.sendMessage(plugin.messages().get("shop.maxed")); return; }
+        Map<Material,Integer> cost = def.costs.get(lvl);
+        if (PriceUtil.hasAndRemove(p, cost)) {
+          st.setManicMiner(lvl+1);
+          plugin.upgrades().applyManicMiner(uh.arenaId, uh.team, st.manicMiner());
+          String name = def.name.replace("{level}", String.valueOf(st.manicMiner()));
+          p.sendMessage(plugin.messages().format("shop.applied", Map.of("name", name)));
+          upgradesMenu.open(p, uh.arenaId, uh.team);
+        } else {
+          p.sendMessage(plugin.messages().format("shop.not-enough", Map.of("cost", PriceUtil.formatCost(cost))));
+        }
+      } else if (slot == TeamUpgradesMenu.SLOT_HEAL) {
+        ShopConfig.UpgradeDef def = plugin.shopConfig().upgrade(UpgradeType.HEAL_POOL);
+        if (st.healPool()) { p.sendMessage(plugin.messages().get("shop.maxed")); return; }
+        Map<Material,Integer> cost = def.costs.get(0);
+        if (PriceUtil.hasAndRemove(p, cost)) {
+          st.setHealPool(true);
+          plugin.upgrades().applyHealPool(uh.arenaId, uh.team, true);
+          p.sendMessage(plugin.messages().format("shop.applied", Map.of("name", def.name)));
+          upgradesMenu.open(p, uh.arenaId, uh.team);
+        } else {
+          p.sendMessage(plugin.messages().format("shop.not-enough", Map.of("cost", PriceUtil.formatCost(cost))));
+        }
+      } else if (slot == TeamUpgradesMenu.SLOT_FORGE) {
+        ShopConfig.UpgradeDef def = plugin.shopConfig().upgrade(UpgradeType.FORGE);
+        int lvl = st.forge();
+        if (lvl >= def.maxLevel) { p.sendMessage(plugin.messages().get("shop.maxed")); return; }
+        Map<Material,Integer> cost = def.costs.get(lvl);
+        if (PriceUtil.hasAndRemove(p, cost)) {
+          st.setForge(lvl+1);
+          plugin.upgrades().applyForge(uh.arenaId, uh.team, st.forge());
+          String name = def.name.replace("{level}", String.valueOf(st.forge()));
+          p.sendMessage(plugin.messages().format("shop.applied", Map.of("name", name)));
+          upgradesMenu.open(p, uh.arenaId, uh.team);
+        } else {
+          p.sendMessage(plugin.messages().format("shop.not-enough", Map.of("cost", PriceUtil.formatCost(cost))));
+        }
+      } else if (slot == TeamUpgradesMenu.SLOT_TRAP) {
+        ShopConfig.TrapDef def = plugin.shopConfig().trap(TrapType.ALARM);
+        if (st.trapQueue().size() >= 3) { p.sendMessage(plugin.messages().get("shop.maxed")); return; }
+        if (PriceUtil.hasAndRemove(p, def.cost)) {
+          st.trapQueue().add(TrapType.ALARM);
+          p.sendMessage(plugin.messages().format("shop.trap-added", Map.of("count", st.trapQueue().size())));
+          upgradesMenu.open(p, uh.arenaId, uh.team);
+        } else {
+          p.sendMessage(plugin.messages().format("shop.not-enough", Map.of("cost", PriceUtil.formatCost(def.cost))));
+        }
+      }
+    }
+  }
+}
+

--- a/src/main/java/com/example/bedwars/shop/TeamUpgradesMenu.java
+++ b/src/main/java/com/example/bedwars/shop/TeamUpgradesMenu.java
@@ -1,0 +1,81 @@
+package com.example.bedwars.shop;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.TeamColor;
+import com.example.bedwars.arena.TeamData;
+import java.util.Map;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * GUI for team upgrades purchased with diamonds.
+ */
+public final class TeamUpgradesMenu {
+  private final BedwarsPlugin plugin;
+
+  public static final int SLOT_SHARP = 10;
+  public static final int SLOT_PROT = 12;
+  public static final int SLOT_HASTE = 14;
+  public static final int SLOT_HEAL = 16;
+  public static final int SLOT_FORGE = 28;
+  public static final int SLOT_TRAP = 30;
+
+  public TeamUpgradesMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
+
+  public void open(Player p, String arenaId, TeamColor team) {
+    String title = plugin.messages().get("shop.upgrades-title");
+    Inventory inv = Bukkit.createInventory(new Holder(arenaId, team), 54, title);
+    TeamData td = plugin.arenas().get(arenaId).map(a->a.team(team)).orElse(null);
+    TeamUpgradesState st = td != null ? td.upgrades() : new TeamUpgradesState();
+
+    inv.setItem(SLOT_SHARP, icon(Material.DIAMOND_SWORD, UpgradeType.SHARPNESS, st.sharpness()?1:0));
+    inv.setItem(SLOT_PROT, icon(Material.DIAMOND_BOOTS, UpgradeType.PROTECTION, st.protection()));
+    inv.setItem(SLOT_HASTE, icon(Material.GOLDEN_PICKAXE, UpgradeType.MANIC_MINER, st.manicMiner()));
+    inv.setItem(SLOT_HEAL, icon(Material.BEACON, UpgradeType.HEAL_POOL, st.healPool()?1:0));
+    inv.setItem(SLOT_FORGE, icon(Material.FURNACE, UpgradeType.FORGE, st.forge()));
+    inv.setItem(SLOT_TRAP, trapIcon(st));
+
+    p.openInventory(inv);
+  }
+
+  private ItemStack icon(Material mat, UpgradeType type, int level) {
+    ShopConfig.UpgradeDef def = plugin.shopConfig().upgrade(type);
+    ItemStack it = new ItemStack(mat);
+    ItemMeta im = it.getItemMeta();
+    if (im != null && def != null) {
+      im.setDisplayName(ChatColor.AQUA + type.name() + " " + level + "/" + def.maxLevel);
+      if (level < def.maxLevel) {
+        Map<Material,Integer> cost = def.costs.get(Math.min(level, def.costs.size()-1));
+        im.setLore(java.util.List.of(ChatColor.GRAY + PriceUtil.formatCost(cost)));
+      } else {
+        im.setLore(java.util.List.of(ChatColor.GRAY + plugin.messages().get("shop.maxed")));
+      }
+      it.setItemMeta(im);
+    }
+    return it;
+  }
+
+  private ItemStack trapIcon(TeamUpgradesState st) {
+    ShopConfig.TrapDef def = plugin.shopConfig().trap(TrapType.ALARM);
+    ItemStack it = new ItemStack(Material.TRIPWIRE_HOOK);
+    ItemMeta im = it.getItemMeta();
+    if (im != null && def != null) {
+      im.setDisplayName(ChatColor.LIGHT_PURPLE + "Traps " + st.trapQueue().size() + "/3");
+      im.setLore(java.util.List.of(ChatColor.GRAY + PriceUtil.formatCost(def.cost)));
+      it.setItemMeta(im);
+    }
+    return it;
+  }
+
+  static final class Holder implements InventoryHolder {
+    final String arenaId; final TeamColor team;
+    Holder(String arenaId, TeamColor team){ this.arenaId = arenaId; this.team = team; }
+    @Override public Inventory getInventory(){ return null; }
+  }
+}

--- a/src/main/java/com/example/bedwars/shop/TeamUpgradesState.java
+++ b/src/main/java/com/example/bedwars/shop/TeamUpgradesState.java
@@ -1,0 +1,29 @@
+package com.example.bedwars.shop;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Holds the state of purchased upgrades for a team.
+ */
+public final class TeamUpgradesState {
+  private boolean sharpness = false;     // +Sharpness I on swords
+  private int protection = 0;            // 0..4
+  private int manicMiner = 0;            // 0..2
+  private boolean healPool = false;      // regen around base
+  private int forge = 0;                 // 0..4
+  private final Deque<TrapType> trapQueue = new ArrayDeque<>(3);
+
+  public boolean sharpness() { return sharpness; }
+  public int protection()    { return protection; }
+  public int manicMiner()    { return manicMiner; }
+  public boolean healPool()  { return healPool; }
+  public int forge()         { return forge; }
+  public Deque<TrapType> trapQueue() { return trapQueue; }
+
+  public void setSharpness(boolean v){ this.sharpness = v; }
+  public void setProtection(int lvl){ this.protection = Math.max(0, Math.min(4, lvl)); }
+  public void setManicMiner(int lvl){ this.manicMiner = Math.max(0, Math.min(2, lvl)); }
+  public void setHealPool(boolean v){ this.healPool = v; }
+  public void setForge(int lvl){ this.forge = Math.max(0, Math.min(4, lvl)); }
+}

--- a/src/main/java/com/example/bedwars/shop/UpgradeService.java
+++ b/src/main/java/com/example/bedwars/shop/UpgradeService.java
@@ -1,0 +1,95 @@
+package com.example.bedwars.shop;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.TeamColor;
+import com.example.bedwars.arena.TeamData;
+import com.example.bedwars.service.PlayerContextService;
+import com.example.bedwars.service.PlayerContextService.Context;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Applies upgrades to players based on team state.
+ * This implementation is intentionally simple and may be expanded later.
+ */
+public final class UpgradeService {
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService ctx;
+  private final Map<String,Integer> healTasks = new HashMap<>();
+
+  public UpgradeService(BedwarsPlugin plugin, PlayerContextService ctx) {
+    this.plugin = plugin; this.ctx = ctx;
+  }
+
+  private boolean matches(Player p, String arenaId, TeamColor team) {
+    return ctx.get(p).map(c -> c.arenaId.equals(arenaId) && c.team == team).orElse(false);
+  }
+
+  public void applySharpness(String arenaId, TeamColor team) {
+    for (Player p : plugin.getServer().getOnlinePlayers()) {
+      if (!matches(p, arenaId, team)) continue;
+      for (ItemStack is : p.getInventory().getContents()) {
+        if (is != null && is.getType().name().endsWith("_SWORD")) {
+          is.addEnchantment(Enchantment.DAMAGE_ALL, 1);
+        }
+      }
+    }
+  }
+
+  public void applyProtection(String arenaId, TeamColor team, int level) {
+    for (Player p : plugin.getServer().getOnlinePlayers()) {
+      if (!matches(p, arenaId, team)) continue;
+      ItemStack[] armor = p.getInventory().getArmorContents();
+      for (ItemStack is : armor) {
+        if (is != null && is.getType() != org.bukkit.Material.AIR) {
+          is.addEnchantment(Enchantment.PROTECTION_ENVIRONMENTAL, level);
+        }
+      }
+      p.getInventory().setArmorContents(armor);
+    }
+  }
+
+  public void applyManicMiner(String arenaId, TeamColor team, int level) {
+    for (Player p : plugin.getServer().getOnlinePlayers()) {
+      if (!matches(p, arenaId, team)) continue;
+      if (level > 0) {
+        p.addPotionEffect(new PotionEffect(PotionEffectType.FAST_DIGGING, Integer.MAX_VALUE, level-1, true, false, false));
+      } else {
+        p.removePotionEffect(PotionEffectType.FAST_DIGGING);
+      }
+    }
+  }
+
+  public void applyHealPool(String arenaId, TeamColor team, boolean enable) {
+    String key = arenaId + ":" + team.name();
+    if (enable) {
+      if (healTasks.containsKey(key)) return;
+      int task = plugin.getServer().getScheduler().runTaskTimer(plugin, () -> {
+        plugin.arenas().get(arenaId).ifPresent(a -> {
+          TeamData td = a.team(team);
+          if (td.spawn() == null) return;
+          for (Player p : plugin.getServer().getOnlinePlayers()) {
+            if (!matches(p, arenaId, team)) continue;
+            if (p.getLocation().distanceSquared(td.spawn()) <= 36) {
+              p.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 60, 0, true, false, false));
+            }
+          }
+        });
+      }, 0L, 40L).getTaskId();
+      healTasks.put(key, task);
+    } else {
+      Integer id = healTasks.remove(key);
+      if (id != null) plugin.getServer().getScheduler().cancelTask(id);
+    }
+  }
+
+  public void applyForge(String arenaId, TeamColor team, int level) {
+    // placeholder - actual generator boosting is implemented later
+  }
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -78,3 +78,13 @@ editor:
   deleted: "&aArène supprimée."
   confirm-delete: "&cTapez &eCONFIRM &cpour supprimer l'arène &e{arena}&c (30s)."
   timeout: "&cPrompt expiré."
+
+shop:
+  title: "&8Boutique &7({cat})"
+  upgrades-title: "&8Améliorations d'équipe"
+  no-context: "&cVous devez être dans une arène et une équipe."
+  bought: "&aAchat: &f{item}"
+  not-enough: "&cRessources insuffisantes: &f{cost}"
+  maxed: "&7Déjà au niveau maximal."
+  applied: "&aAmélioration appliquée: &f{name}"
+  trap-added: "&aPiège ajouté. File: {count}/3"

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -1,0 +1,66 @@
+currencies:
+  IRON: IRON_INGOT
+  GOLD: GOLD_INGOT
+  DIAMOND: DIAMOND
+  EMERALD: EMERALD
+
+items:
+  BLOCKS:
+    - id: "wool_16"
+      mat: "WOOL_TEAM"
+      amount: 16
+      price: { GOLD: 4 }
+      name: "&fLaine (&7{team}&f) x16"
+    - id: "glass_4"
+      mat: "WHITE_STAINED_GLASS"
+      amount: 4
+      price: { IRON: 12 }
+      name: "&fVerre renforcé x4"
+
+  MELEE:
+    - id: "stone_sword"
+      mat: "STONE_SWORD"
+      enchants: { DAMAGE_ALL: 1 }
+      price: { IRON: 10 }
+      name: "&fÉpée en pierre"
+
+  ARMOR:
+    - id: "permanent_iron_armor"
+      mat: "IRON_BOOTS"
+      price: { GOLD: 12 }
+      name: "&fArmure permanente : &7maille→fer"
+
+  TOOLS:
+    - id: "shears"
+      mat: "SHEARS"
+      price: { IRON: 20 }
+      name: "&fCisailles"
+
+  UTILITY:
+    - id: "tnt"
+      mat: "TNT"
+      amount: 1
+      price: { GOLD: 8 }
+      name: "&fTNT"
+
+upgrades:
+  SHARPNESS:
+    cost: { DIAMOND: 4 }
+    maxLevel: 1
+    name: "&bAffûtage (Sharpness I)"
+  PROTECTION:
+    costs: [ {DIAMOND:2}, {DIAMOND:4}, {DIAMOND:6}, {DIAMOND:8} ]
+    name: "&bProtection d'équipe {level}"
+  MANIC_MINER:
+    costs: [ {DIAMOND:2}, {DIAMOND:4} ]
+    name: "&bManic Miner {level}"
+  HEAL_POOL:
+    cost: { DIAMOND: 3 }
+    name: "&bHeal Pool"
+  FORGE:
+    costs: [ {DIAMOND:2}, {DIAMOND:4}, {DIAMOND:6}, {DIAMOND:8} ]
+    name: "&bForge {level}"
+  TRAPS:
+    alarm:
+      cost: { DIAMOND: 1 }
+      name: "&dPiège: Alarme"


### PR DESCRIPTION
## Summary
- implement team upgrade state and player context service
- load configurable item and upgrade shops
- handle NPC interactions with item and upgrade menus

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bd4d7c7748329b4b139ee1902405d