### PR TITLE
fix: update upgrades for 1.21

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -9,6 +9,7 @@ import com.example.bedwars.arena.ArenaManager;
 import com.example.bedwars.gui.MenuManager;
 import com.example.bedwars.listeners.MenuListener;
 import com.example.bedwars.listeners.EditorListener;
+import com.example.bedwars.listeners.UpgradeApplyListener;
 import com.example.bedwars.setup.PromptService;
 import com.example.bedwars.shop.ShopConfig;
 import com.example.bedwars.shop.UpgradeService;
@@ -46,6 +47,7 @@ public final class BedwarsPlugin extends JavaPlugin {
     getServer().getPluginManager().registerEvents(new EditorListener(this), this);
     getServer().getPluginManager().registerEvents(promptService, this);
     getServer().getPluginManager().registerEvents(new ShopListener(this, contextService), this);
+    getServer().getPluginManager().registerEvents(new UpgradeApplyListener(this, contextService), this);
 
     getLogger().info("Bedwars loaded.");
   }

--- a/src/main/java/com/example/bedwars/listeners/UpgradeApplyListener.java
+++ b/src/main/java/com/example/bedwars/listeners/UpgradeApplyListener.java
@@ -1,0 +1,42 @@
+package com.example.bedwars.listeners;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.TeamData;
+import com.example.bedwars.service.PlayerContextService;
+import com.example.bedwars.shop.TeamUpgradesState;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
+
+public final class UpgradeApplyListener implements Listener {
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService ctx;
+
+  public UpgradeApplyListener(BedwarsPlugin plugin, PlayerContextService ctx) {
+    this.plugin = plugin;
+    this.ctx = ctx;
+  }
+
+  @EventHandler
+  public void onSwitch(PlayerItemHeldEvent e) {
+    Player p = e.getPlayer();
+    ctx.get(p).ifPresent(c -> plugin.upgrades().applySharpness(c.arenaId, c.team));
+  }
+
+  @EventHandler
+  public void onInventory(InventoryClickEvent e) {
+    if (!(e.getWhoClicked() instanceof Player p)) return;
+    ctx.get(p).ifPresent(c -> {
+      plugin.arenas().get(c.arenaId).ifPresent(arena -> {
+        TeamData td = arena.team(c.team);
+        TeamUpgradesState st = td.upgrades();
+        plugin.getServer().getScheduler().runTask(plugin, () -> {
+          plugin.upgrades().applySharpness(c.arenaId, c.team);
+          plugin.upgrades().applyProtection(c.arenaId, c.team, st.protection());
+        });
+      });
+    });
+  }
+}

--- a/src/main/java/com/example/bedwars/util/Compat.java
+++ b/src/main/java/com/example/bedwars/util/Compat.java
@@ -1,0 +1,25 @@
+package com.example.bedwars.util;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.potion.PotionEffectType;
+
+public final class Compat {
+  private Compat(){}
+
+  public static Enchantment sharpness() {
+    Enchantment e = Enchantment.SHARPNESS; // 1.21+
+    if (e == null) e = Enchantment.getByKey(NamespacedKey.minecraft("damage_all"));
+    return e;
+  }
+  public static Enchantment protection() {
+    Enchantment e = Enchantment.PROTECTION; // 1.21+
+    if (e == null) e = Enchantment.getByKey(NamespacedKey.minecraft("protection_environmental"));
+    return e;
+  }
+  public static PotionEffectType haste() {
+    PotionEffectType t = PotionEffectType.HASTE; // 1.21+
+    if (t == null) t = PotionEffectType.getByName("FAST_DIGGING");
+    return t;
+  }
+}

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -20,7 +20,7 @@ items:
   MELEE:
     - id: "stone_sword"
       mat: "STONE_SWORD"
-      enchants: { DAMAGE_ALL: 1 }
+      enchants: { SHARPNESS: 1 }
       price: { IRON: 10 }
       name: "&fÉpée en pierre"
 


### PR DESCRIPTION
## Summary
- add Compat utility for Sharpness, Protection and Haste lookups
- apply new enchantment and effect names in UpgradeService
- reapply upgrades on item and armor changes via new listener
- register listener and update shop config

## Testing
- `mvn -q -e clean package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bd721e4cc832997d7b10748392083