### PR TITLE
Étape 6 – Générateurs et scheduler central

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -11,11 +11,13 @@ import com.example.bedwars.ops.Keys;
 import com.example.bedwars.listeners.MenuListener;
 import com.example.bedwars.listeners.EditorListener;
 import com.example.bedwars.listeners.UpgradeApplyListener;
+import com.example.bedwars.listeners.GameStateListener;
 import com.example.bedwars.setup.PromptService;
 import com.example.bedwars.shop.ShopConfig;
 import com.example.bedwars.shop.UpgradeService;
 import com.example.bedwars.shop.ShopListener;
 import com.example.bedwars.service.PlayerContextService;
+import com.example.bedwars.gen.GeneratorManager;
 
 public final class BedwarsPlugin extends JavaPlugin {
 
@@ -28,6 +30,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   private ShopConfig shopConfig;
   private PlayerContextService contextService;
   private UpgradeService upgradeService;
+  private GeneratorManager generatorManager;
 
   @Override
   public void onEnable() {
@@ -42,6 +45,8 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.shopConfig = new ShopConfig(this);
     this.contextService = new PlayerContextService();
     this.upgradeService = new UpgradeService(this, contextService);
+    this.generatorManager = new GeneratorManager(this);
+    this.generatorManager.start();
 
     Objects.requireNonNull(getCommand("bw")).setExecutor(new BwCommand(this));
     Objects.requireNonNull(getCommand("bwadmin")).setExecutor(new BwAdminCommand(this));
@@ -51,6 +56,7 @@ public final class BedwarsPlugin extends JavaPlugin {
     getServer().getPluginManager().registerEvents(promptService, this);
     getServer().getPluginManager().registerEvents(new ShopListener(this, contextService), this);
     getServer().getPluginManager().registerEvents(new UpgradeApplyListener(this, contextService), this);
+    getServer().getPluginManager().registerEvents(new GameStateListener(this), this);
 
     getLogger().info("Bedwars loaded.");
   }
@@ -58,6 +64,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   @Override
   public void onDisable() {
     if (arenaManager != null) arenaManager.saveAll();
+    if (generatorManager != null) generatorManager.stop();
     getLogger().info("Bedwars disabled.");
   }
 
@@ -88,4 +95,5 @@ public final class BedwarsPlugin extends JavaPlugin {
   public ShopConfig shopConfig() { return shopConfig; }
   public PlayerContextService contexts() { return contextService; }
   public UpgradeService upgrades() { return upgradeService; }
+  public GeneratorManager generators() { return generatorManager; }
 }

--- a/src/main/java/com/example/bedwars/game/ArenaStateChangeEvent.java
+++ b/src/main/java/com/example/bedwars/game/ArenaStateChangeEvent.java
@@ -1,0 +1,30 @@
+package com.example.bedwars.game;
+
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.GameState;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Simple event fired when an arena changes state.
+ */
+public final class ArenaStateChangeEvent extends Event {
+  private static final HandlerList HANDLERS = new HandlerList();
+  private final Arena arena;
+  private final GameState oldState;
+  private final GameState newState;
+
+  public ArenaStateChangeEvent(Arena arena, GameState oldState, GameState newState) {
+    this.arena = arena;
+    this.oldState = oldState;
+    this.newState = newState;
+  }
+
+  public Arena arena() { return arena; }
+  public GameState oldState() { return oldState; }
+  public GameState newState() { return newState; }
+
+  @Override
+  public HandlerList getHandlers() { return HANDLERS; }
+  public static HandlerList getHandlerList() { return HANDLERS; }
+}

--- a/src/main/java/com/example/bedwars/gen/GenUtils.java
+++ b/src/main/java/com/example/bedwars/gen/GenUtils.java
@@ -1,0 +1,125 @@
+package com.example.bedwars.gen;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.TeamColor;
+import com.example.bedwars.shop.TeamUpgradesState;
+import com.example.bedwars.ops.Keys;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Display;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.TextDisplay;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.UUID;
+
+/**
+ * Helper utilities for generator runtime.
+ */
+public final class GenUtils {
+
+  private GenUtils(){}
+
+  // Is generator a base one (iron/gold near team spawn)?
+  public static boolean isBaseGenerator(Arena arena, com.example.bedwars.gen.Generator g, double radius) {
+    if (g.type() != GeneratorType.IRON && g.type() != GeneratorType.GOLD) return false;
+    var loc = g.location();
+    for (var entry : arena.teams().entrySet()) {
+      var td = entry.getValue();
+      if (td.spawn() == null) continue;
+      if (!loc.getWorld().equals(td.spawn().getWorld())) continue;
+      if (loc.distanceSquared(td.spawn()) <= radius * radius) return true;
+    }
+    return false;
+  }
+
+  // Compute forge multiplier (max level across enabled teams)
+  public static double forgeMultiplier(Arena arena) {
+    int lvl = 0;
+    for (TeamColor tc : arena.enabledTeams()) {
+      TeamUpgradesState up = arena.team(tc).upgrades();
+      if (up != null) lvl = Math.max(lvl, up.forge());
+    }
+    return BedwarsPlugin.get().getConfig().getDouble("forge.multipliers." + lvl, 1.0);
+  }
+
+  // Drop the item corresponding to generator type and tag with PDC
+  public static void drop(BedwarsPlugin plugin, String arenaId, UUID genId, RuntimeGen rg, int amount) {
+    Material mat = Material.matchMaterial(plugin.getConfig().getString("drops." + rg.type.name()));
+    if (mat == null) mat = Material.IRON_INGOT;
+    ItemStack stack = new ItemStack(mat, amount);
+
+    World world = rg.dropLoc.getWorld();
+    world.dropItem(rg.dropLoc, stack, it -> {
+      it.setVelocity(new org.bukkit.util.Vector(0, 0.1, 0));
+      var pdc = it.getPersistentDataContainer();
+      Keys keys = plugin.keys();
+      pdc.set(keys.ARENA_ID(), PersistentDataType.STRING, arenaId);
+      pdc.set(keys.GEN_ID(), PersistentDataType.STRING, genId.toString());
+    });
+  }
+
+  // Hologram utilities (TextDisplay)
+  public static void spawnOrUpdateHolo(BedwarsPlugin plugin, String arenaId, UUID genId, RuntimeGen rg) {
+    updateHolo(plugin, arenaId, genId, rg); // update handles creation if absent
+  }
+
+  public static void updateHolo(BedwarsPlugin plugin, String arenaId, UUID genId, RuntimeGen rg) {
+    if (!plugin.getConfig().getBoolean("holograms.enabled", true)) return;
+    double y = plugin.getConfig().getDouble("holograms.y-offset", 1.7);
+    Location holoLoc = rg.dropLoc.clone().add(0, y, 0);
+
+    TextDisplay td = null;
+    for (var ent : holoLoc.getWorld().getNearbyEntities(holoLoc, 0.6, 1.2, 0.6, e -> e instanceof TextDisplay)) {
+      var pdc = ent.getPersistentDataContainer();
+      Keys keys = plugin.keys();
+      String a = pdc.get(keys.ARENA_ID(), PersistentDataType.STRING);
+      String gid = pdc.get(keys.GEN_ID(), PersistentDataType.STRING);
+      if (arenaId.equals(a) && genId.toString().equals(gid) && pdc.has(keys.GEN_HOLO(), PersistentDataType.STRING)) {
+        td = (TextDisplay) ent;
+        break;
+      }
+    }
+    if (td == null) {
+      td = (TextDisplay) holoLoc.getWorld().spawn(holoLoc, TextDisplay.class, d -> {
+        Keys keys = plugin.keys();
+        var pdc = d.getPersistentDataContainer();
+        pdc.set(keys.ARENA_ID(), PersistentDataType.STRING, arenaId);
+        pdc.set(keys.GEN_ID(), PersistentDataType.STRING, genId.toString());
+        pdc.set(keys.GEN_HOLO(), PersistentDataType.STRING, "1");
+        d.setBillboard(Display.Billboard.CENTER);
+        d.setShadowed(false);
+        d.setSeeThrough(false);
+        d.setViewRange(32);
+      });
+    }
+    String l1 = color(plugin.getConfig().getString("holograms.line-1", "&b{type} &7T{tier}")
+        .replace("{type}", rg.type.name())
+        .replace("{tier}", String.valueOf(rg.tier)));
+    String l2 = color(plugin.getConfig().getString("holograms.line-2", "&f{cooldown}s")
+        .replace("{cooldown}", String.valueOf(Math.max(0, rg.current / 20))));
+    td.setText(l1 + "\n" + l2);
+  }
+
+  private static String color(String s) {
+    return org.bukkit.ChatColor.translateAlternateColorCodes('&', s);
+  }
+
+  // Remove setup markers (ArmorStand/TextDisplay tagged GEN_MARKER)
+  public static void removeSetupMarkers(Arena arena) {
+    World w = arena.lobby() != null ? arena.lobby().getWorld() : Bukkit.getWorld(arena.world().name());
+    if (w == null) return;
+    for (var ent : w.getEntities()) {
+      var pdc = ent.getPersistentDataContainer();
+      Keys keys = BedwarsPlugin.get().keys();
+      String a = pdc.get(keys.ARENA_ID(), PersistentDataType.STRING);
+      if (arena.id().equals(a) && pdc.has(keys.GEN_MARKER(), PersistentDataType.STRING)) {
+        ent.remove();
+      }
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/gen/GeneratorManager.java
+++ b/src/main/java/com/example/bedwars/gen/GeneratorManager.java
@@ -1,0 +1,132 @@
+package com.example.bedwars.gen;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.GameState;
+import com.example.bedwars.ops.Keys;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.entity.Item;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.*;
+import java.util.UUID;
+
+/**
+ * Central scheduler handling generator ticks.
+ */
+public final class GeneratorManager {
+  private final BedwarsPlugin plugin;
+  private final Map<String, Map<UUID, RuntimeGen>> runtime = new HashMap<>();
+  private int taskId = -1;
+
+  public GeneratorManager(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+  }
+
+  public void start() {
+    if (taskId != -1) return;
+    taskId = new BukkitRunnable() {
+      @Override public void run() { tickAll(); }
+    }.runTaskTimer(plugin, 20L, 20L).getTaskId();
+  }
+
+  public void stop() {
+    if (taskId != -1) {
+      Bukkit.getScheduler().cancelTask(taskId);
+      taskId = -1;
+    }
+    runtime.keySet().forEach(this::cleanupArena);
+    runtime.clear();
+  }
+
+  // Called at STARTING->RUNNING and on arena reload
+  public void refreshArena(String arenaId) {
+    plugin.arenas().get(arenaId).ifPresent(arena -> {
+      Map<UUID, RuntimeGen> map = new LinkedHashMap<>();
+      World w = Bukkit.getWorld(arena.world().name());
+      if (w == null) {
+        plugin.getLogger().warning("World not loaded for arena " + arenaId);
+        return;
+      }
+
+      double yOff = plugin.getConfig().getDouble("generators.spawn-offset-y", 0.5);
+      for (var g : arena.generators()) {
+        var loc = g.location().clone();
+        loc.setWorld(w);
+        loc.add(0, yOff, 0);
+
+        int interval = g.intervalTicks() > 0 ? g.intervalTicks()
+            : plugin.getConfig().getInt("generators.base-intervals." + g.type().name(), 120);
+        int amount = g.amount() > 0 ? g.amount()
+            : plugin.getConfig().getInt("generators.base-amounts." + g.type().name(), 1);
+
+        RuntimeGen rg = new RuntimeGen(g.type(), loc, g.tier(), interval, amount);
+        rg.isBase = GenUtils.isBaseGenerator(arena, g,
+            plugin.getConfig().getDouble("generators.base-radius", 10.0));
+        map.put(g.id(), rg);
+
+        if (plugin.getConfig().getBoolean("holograms.enabled", true)) {
+          GenUtils.spawnOrUpdateHolo(plugin, arenaId, g.id(), rg);
+        }
+      }
+      runtime.put(arenaId, map);
+    });
+  }
+
+  public void cleanupArena(String arenaId) {
+    plugin.arenas().get(arenaId).ifPresent(arena -> {
+      World w = Bukkit.getWorld(arena.world().name());
+      if (w == null) return;
+
+      Keys keys = plugin.keys();
+      w.getEntities().forEach(ent -> {
+        var pdc = ent.getPersistentDataContainer();
+        String a = pdc.get(keys.ARENA_ID(), PersistentDataType.STRING);
+        if (!arenaId.equals(a)) return;
+        if (pdc.has(keys.GEN_HOLO(), PersistentDataType.STRING)) ent.remove();
+        if (ent instanceof Item item && pdc.has(keys.GEN_ID(), PersistentDataType.STRING)) item.remove();
+      });
+    });
+  }
+
+  private void tickAll() {
+    plugin.arenas().all().forEach(arena -> {
+      if (arena.state() != GameState.RUNNING) return;
+      Map<UUID, RuntimeGen> map = runtime.get(arena.id());
+      if (map == null) return;
+
+      double forgeMul = GenUtils.forgeMultiplier(arena);
+      for (var entry : map.entrySet()) {
+        UUID genId = entry.getKey();
+        RuntimeGen rg = entry.getValue();
+
+        rg.current -= 20;
+        if (rg.current > 0) {
+          GenUtils.updateHolo(plugin, arena.id(), genId, rg);
+          continue;
+        }
+
+        int amount = rg.baseAmount;
+        if (rg.isBase && (rg.type == GeneratorType.IRON || rg.type == GeneratorType.GOLD)) {
+          amount = Math.max(1, (int) Math.round(amount * forgeMul));
+        }
+        GenUtils.drop(plugin, arena.id(), genId, rg, amount);
+        rg.current = rg.baseInterval;
+        GenUtils.updateHolo(plugin, arena.id(), genId, rg);
+      }
+    });
+  }
+
+  // Called when arena state changes
+  public void onArenaStateChange(Arena arena, GameState oldS, GameState newS) {
+    if (oldS == GameState.STARTING && newS == GameState.RUNNING) {
+      GenUtils.removeSetupMarkers(arena);
+      refreshArena(arena.id());
+    }
+    if (oldS == GameState.RUNNING && (newS == GameState.ENDING || newS == GameState.RESTARTING || newS == GameState.WAITING)) {
+      cleanupArena(arena.id());
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/gen/RuntimeGen.java
+++ b/src/main/java/com/example/bedwars/gen/RuntimeGen.java
@@ -1,0 +1,25 @@
+package com.example.bedwars.gen;
+
+import org.bukkit.Location;
+
+/**
+ * Runtime state for a generator during a game.
+ */
+public final class RuntimeGen {
+  public final GeneratorType type;
+  public final Location dropLoc;     // world resolved
+  public final int tier;
+  public final int baseInterval;     // ticks
+  public final int baseAmount;
+  public int current;                // ticks remaining
+  public boolean isBase;             // base generator (Forge)
+
+  public RuntimeGen(GeneratorType type, Location dropLoc, int tier, int baseInterval, int baseAmount) {
+    this.type = type;
+    this.dropLoc = dropLoc;
+    this.tier = tier;
+    this.baseInterval = Math.max(1, baseInterval);
+    this.baseAmount = Math.max(1, baseAmount);
+    this.current = this.baseInterval;
+  }
+}

--- a/src/main/java/com/example/bedwars/listeners/GameStateListener.java
+++ b/src/main/java/com/example/bedwars/listeners/GameStateListener.java
@@ -1,0 +1,22 @@
+package com.example.bedwars.listeners;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.game.ArenaStateChangeEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+/**
+ * Listener relaying arena state transitions to the generator manager.
+ */
+public final class GameStateListener implements Listener {
+  private final BedwarsPlugin plugin;
+
+  public GameStateListener(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+  }
+
+  @EventHandler
+  public void onStateChange(ArenaStateChangeEvent event) {
+    plugin.generators().onArenaStateChange(event.arena(), event.oldState(), event.newState());
+  }
+}

--- a/src/main/java/com/example/bedwars/ops/Keys.java
+++ b/src/main/java/com/example/bedwars/ops/Keys.java
@@ -16,6 +16,8 @@ public final class Keys {
   private final NamespacedKey GEN_MARKER;
   private final NamespacedKey GEN_KIND;
   private final NamespacedKey HOLO_KIND;
+  private final NamespacedKey GEN_ID;
+  private final NamespacedKey GEN_HOLO;
 
   public Keys(Plugin plugin) {
     this.ARENA_ID = new NamespacedKey(plugin, "arena_id");
@@ -23,6 +25,8 @@ public final class Keys {
     this.GEN_MARKER = new NamespacedKey(plugin, "gen_marker");
     this.GEN_KIND = new NamespacedKey(plugin, "gen_kind");
     this.HOLO_KIND = new NamespacedKey(plugin, "holo_kind");
+    this.GEN_ID = new NamespacedKey(plugin, "gen_id");
+    this.GEN_HOLO = new NamespacedKey(plugin, "gen_holo");
   }
 
   public NamespacedKey ARENA_ID() { return ARENA_ID; }
@@ -34,5 +38,9 @@ public final class Keys {
   public NamespacedKey GEN_KIND() { return GEN_KIND; }
 
   public NamespacedKey HOLO_KIND() { return HOLO_KIND; }
+
+  public NamespacedKey GEN_ID() { return GEN_ID; }
+
+  public NamespacedKey GEN_HOLO() { return GEN_HOLO; }
 }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,37 @@
 # Configuration de base - Etape 0
 language: fr
 debug: false
+
+generators:
+  base-intervals:
+    IRON: 120
+    GOLD: 300
+    DIAMOND: 900
+    EMERALD: 1800
+  base-amounts:
+    IRON: 1
+    GOLD: 1
+    DIAMOND: 1
+    EMERALD: 1
+  spawn-offset-y: 0.5
+  base-radius: 10.0
+
+drops:
+  IRON: IRON_INGOT
+  GOLD: GOLD_INGOT
+  DIAMOND: DIAMOND
+  EMERALD: EMERALD
+
+forge:
+  multipliers:
+    0: 1.00
+    1: 1.25
+    2: 1.50
+    3: 1.75
+    4: 2.00
+
+holograms:
+  enabled: true
+  line-1: "&b{type} &7T{tier}"
+  line-2: "&f{cooldown}s"
+  y-offset: 1.7


### PR DESCRIPTION
## Summary
- Implement GeneratorManager ticking every second to drive arena generators
- Add runtime generator state, Forge multipliers, drops and hologram updates
- Integrate generator manager into plugin lifecycle and expose new config/keys

## Testing
- `mvn -q -e package` *(fails: Network is unreachable when resolving plugins)*

------
https://chatgpt.com/codex/tasks/task_e_689c4506926c8329881bf54e23c233aa