### PR TITLE
Fix cooldown reference in GenUtils hologram

### DIFF
--- a/src/main/java/com/example/bedwars/gen/GenUtils.java
+++ b/src/main/java/com/example/bedwars/gen/GenUtils.java
@@ -106,7 +106,7 @@ public final class GenUtils {
         .replace("{type}", rg.type.name())
         .replace("{tier}", String.valueOf(rg.tier)));
     String l2 = color(plugin.getConfig().getString("holograms.line-2", "&f{cooldown}s")
-        .replace("{cooldown}", String.valueOf(Math.max(0, rg.current / 20))));
+        .replace("{cooldown}", String.valueOf(Math.max(0, rg.cooldown / 20))));
     td.setText(l1 + "\n" + l2);
   }
 


### PR DESCRIPTION
## Summary
- show hologram cooldown using `RuntimeGen.cooldown`
- ensure generator helpers remain runtime-independent with Spigot `getNearbyEntities`

## Testing
- `mvn -q clean package` *(fails: Network is unreachable)*
- `mvn -q -o clean package` *(fails: Cannot access central in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_689c58356bfc83298c73d3bd469fce54