### PR TITLE
Refactor generators, shop, and upgrades for new currencies and holograms

### DIFF
--- a/src/main/java/com/example/bedwars/game/GameService.java
+++ b/src/main/java/com/example/bedwars/game/GameService.java
@@ -36,6 +36,18 @@ public final class GameService {
     this.messages = msgs;
   }
 
+  public int diamondTier(String arenaId) {
+    return plugin.generators().diamondTier(arenaId);
+  }
+
+  public int emeraldTier(String arenaId) {
+    return plugin.generators().emeraldTier(arenaId);
+  }
+
+  public int nextDropSeconds(String arenaId, java.util.UUID genId) {
+    return plugin.generators().cooldownSeconds(arenaId, genId);
+  }
+
   public void join(Player p, String arenaId) {
     if (contexts.getArena(p) != null) {
       messages.send(p, "game.already-in", Map.of());

--- a/src/main/java/com/example/bedwars/gen/GenHologramService.java
+++ b/src/main/java/com/example/bedwars/gen/GenHologramService.java
@@ -4,14 +4,14 @@ import com.example.bedwars.BedwarsPlugin;
 import com.example.bedwars.ops.Keys;
 import org.bukkit.Location;
 import org.bukkit.entity.Display;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.persistence.PersistentDataType;
 
-import java.util.Map;
 import java.util.UUID;
 
 /**
- * Handles spawning and updating holograms for generators.
+ * Handles spawning and updating holograms for diamond/emerald generators.
  */
 public final class GenHologramService {
   private final BedwarsPlugin plugin;
@@ -20,18 +20,18 @@ public final class GenHologramService {
     this.plugin = plugin;
   }
 
-  public void spawnOrUpdate(String arenaId, RuntimeGen g, int count, boolean capReached) {
+  public void updateOrCreate(String arenaId, UUID genId, Location loc, GeneratorType type, int tier, int seconds) {
     if (!plugin.getConfig().getBoolean("holograms.enabled", true)) return;
     double y = plugin.getConfig().getDouble("holograms.y_offset", 1.7);
-    Location holoLoc = g.dropLoc.clone().add(0, y, 0);
+    Location holoLoc = loc.clone().add(0, y, 0);
 
     TextDisplay td = null;
-    for (var ent : holoLoc.getWorld().getNearbyEntities(holoLoc, 0.6, 1.2, 0.6, e -> e instanceof TextDisplay)) {
+    for (Entity ent : holoLoc.getWorld().getNearbyEntities(holoLoc, 0.6, 1.2, 0.6, e -> e instanceof TextDisplay)) {
       var pdc = ent.getPersistentDataContainer();
       Keys keys = plugin.keys();
       String a = pdc.get(keys.ARENA_ID(), PersistentDataType.STRING);
       String gid = pdc.get(keys.GEN_ID(), PersistentDataType.STRING);
-      if (arenaId.equals(a) && g.id.toString().equals(gid) && pdc.has(keys.GEN_HOLO(), PersistentDataType.STRING)) {
+      if (arenaId.equals(a) && genId.toString().equals(gid) && pdc.has(keys.GEN_HOLO(), PersistentDataType.STRING)) {
         td = (TextDisplay) ent;
         break;
       }
@@ -41,7 +41,7 @@ public final class GenHologramService {
         Keys keys = plugin.keys();
         var pdc = d.getPersistentDataContainer();
         pdc.set(keys.ARENA_ID(), PersistentDataType.STRING, arenaId);
-        pdc.set(keys.GEN_ID(), PersistentDataType.STRING, g.id.toString());
+        pdc.set(keys.GEN_ID(), PersistentDataType.STRING, genId.toString());
         pdc.set(keys.GEN_HOLO(), PersistentDataType.STRING, "1");
         d.setBillboard(Display.Billboard.CENTER);
         d.setShadowed(false);
@@ -50,16 +50,24 @@ public final class GenHologramService {
       });
     }
     String line1 = plugin.getConfig().getString("holograms.line_1", "&b{type} &7T{tier}")
-        .replace("{type}", g.type.name()).replace("{tier}", String.valueOf(g.tier));
-    String line2 = plugin.getConfig().getString("holograms.line_2", "&f{cooldown}s &7(Cap {count}/{cap})")
-        .replace("{cooldown}", String.valueOf(Math.max(0, g.cooldown / 20)))
-        .replace("{count}", String.valueOf(count))
-        .replace("{cap}", String.valueOf(g.cap));
-    if (capReached) {
-      line2 = plugin.messages().format("gens.cap_reached",
-          Map.of("type", g.type.name(), "count", count, "cap", g.cap));
-    }
+        .replace("{type}", type.name())
+        .replace("{tier}", String.valueOf(tier));
+    String line2 = plugin.getConfig().getString("holograms.line_2", "&f{cooldown}s")
+        .replace("{cooldown}", String.valueOf(seconds));
     td.setText(color(line1) + "\n" + color(line2));
+  }
+
+  public void removeAll(String arenaId) {
+    var keys = plugin.keys();
+    for (var world : plugin.getServer().getWorlds()) {
+      for (Entity ent : world.getEntitiesByClass(TextDisplay.class)) {
+        var pdc = ent.getPersistentDataContainer();
+        String a = pdc.get(keys.ARENA_ID(), PersistentDataType.STRING);
+        if (arenaId.equals(a) && pdc.has(keys.GEN_HOLO(), PersistentDataType.STRING)) {
+          ent.remove();
+        }
+      }
+    }
   }
 
   private String color(String s) {

--- a/src/main/java/com/example/bedwars/gen/GenUtils.java
+++ b/src/main/java/com/example/bedwars/gen/GenUtils.java
@@ -10,10 +10,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Display;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.TextDisplay;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 
@@ -68,51 +66,6 @@ public final class GenUtils {
     });
   }
 
-  // Hologram utilities (TextDisplay)
-  public static void spawnOrUpdateHolo(BedwarsPlugin plugin, String arenaId, UUID genId, RuntimeGen rg) {
-    updateHolo(plugin, arenaId, genId, rg); // update handles creation if absent
-  }
-
-  public static void updateHolo(BedwarsPlugin plugin, String arenaId, UUID genId, RuntimeGen rg) {
-    if (!plugin.getConfig().getBoolean("holograms.enabled", true)) return;
-    double y = plugin.getConfig().getDouble("holograms.y-offset", 1.7);
-    Location holoLoc = rg.dropLoc.clone().add(0, y, 0);
-
-    TextDisplay td = null;
-    for (var ent : holoLoc.getWorld().getNearbyEntities(holoLoc, 0.6, 1.2, 0.6, e -> e instanceof TextDisplay)) {
-      var pdc = ent.getPersistentDataContainer();
-      Keys keys = plugin.keys();
-      String a = pdc.get(keys.ARENA_ID(), PersistentDataType.STRING);
-      String gid = pdc.get(keys.GEN_ID(), PersistentDataType.STRING);
-      if (arenaId.equals(a) && genId.toString().equals(gid) && pdc.has(keys.GEN_HOLO(), PersistentDataType.STRING)) {
-        td = (TextDisplay) ent;
-        break;
-      }
-    }
-    if (td == null) {
-      td = (TextDisplay) holoLoc.getWorld().spawn(holoLoc, TextDisplay.class, d -> {
-        Keys keys = plugin.keys();
-        var pdc = d.getPersistentDataContainer();
-        pdc.set(keys.ARENA_ID(), PersistentDataType.STRING, arenaId);
-        pdc.set(keys.GEN_ID(), PersistentDataType.STRING, genId.toString());
-        pdc.set(keys.GEN_HOLO(), PersistentDataType.STRING, "1");
-        d.setBillboard(Display.Billboard.CENTER);
-        d.setShadowed(false);
-        d.setSeeThrough(false);
-        d.setViewRange(32);
-      });
-    }
-    String l1 = color(plugin.getConfig().getString("holograms.line-1", "&b{type} &7T{tier}")
-        .replace("{type}", rg.type.name())
-        .replace("{tier}", String.valueOf(rg.tier)));
-    String l2 = color(plugin.getConfig().getString("holograms.line-2", "&f{cooldown}s")
-        .replace("{cooldown}", String.valueOf(Math.max(0, rg.cooldown / 20))));
-    td.setText(l1 + "\n" + l2);
-  }
-
-  private static String color(String s) {
-    return org.bukkit.ChatColor.translateAlternateColorCodes('&', s);
-  }
 
   // Remove setup markers (ArmorStand/TextDisplay tagged GEN_MARKER)
   public static void removeSetupMarkers(Arena arena) {

--- a/src/main/java/com/example/bedwars/shop/Currency.java
+++ b/src/main/java/com/example/bedwars/shop/Currency.java
@@ -1,0 +1,23 @@
+package com.example.bedwars.shop;
+
+import org.bukkit.Material;
+
+/**
+ * Supported shop currencies and their corresponding material items.
+ */
+public enum Currency {
+  IRON(Material.IRON_INGOT),
+  GOLD(Material.GOLD_INGOT),
+  EMERALD(Material.EMERALD),
+  DIAMOND(Material.DIAMOND);
+
+  private final Material material;
+
+  Currency(Material material) {
+    this.material = material;
+  }
+
+  public Material material() {
+    return material;
+  }
+}

--- a/src/main/java/com/example/bedwars/shop/ItemShopMenu.java
+++ b/src/main/java/com/example/bedwars/shop/ItemShopMenu.java
@@ -56,7 +56,8 @@ public final class ItemShopMenu {
       if (im != null) {
         String name = si.name.replace("{team}", team.display);
         im.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
-        im.setLore(java.util.List.of(ChatColor.GRAY + PriceUtil.formatCost(si.price)));
+        String lore = ChatColor.GRAY + si.cost + "x " + si.currency.name();
+        im.setLore(java.util.List.of(lore));
         si.enchants.forEach((e,l) -> im.addEnchant(e, l, true));
         it.setItemMeta(im);
       }
@@ -74,3 +75,4 @@ public final class ItemShopMenu {
     @Override public Inventory getInventory(){ return null; }
   }
 }
+

--- a/src/main/java/com/example/bedwars/shop/PurchaseService.java
+++ b/src/main/java/com/example/bedwars/shop/PurchaseService.java
@@ -1,0 +1,42 @@
+package com.example.bedwars.shop;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Utility for counting and removing currencies from player inventories.
+ */
+public final class PurchaseService {
+  private PurchaseService() {}
+
+  public static int count(Player p, Currency c) {
+    return count(p.getInventory(), c);
+  }
+
+  private static int count(Inventory inv, Currency c) {
+    int total = 0;
+    for (ItemStack is : inv.getContents()) {
+      if (is != null && is.getType() == c.material()) total += is.getAmount();
+    }
+    return total;
+  }
+
+  public static boolean tryBuy(Player p, Currency c, int amount) {
+    Inventory inv = p.getInventory();
+    if (count(inv, c) < amount) return false;
+    remove(inv, c, amount);
+    return true;
+  }
+
+  private static void remove(Inventory inv, Currency c, int amount) {
+    for (int i = 0; i < inv.getSize(); i++) {
+      ItemStack is = inv.getItem(i);
+      if (is == null || is.getType() != c.material()) continue;
+      int take = Math.min(amount, is.getAmount());
+      is.setAmount(is.getAmount() - take);
+      amount -= take;
+      if (amount <= 0) break;
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/shop/ShopConfig.java
+++ b/src/main/java/com/example/bedwars/shop/ShopConfig.java
@@ -9,164 +9,73 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.enchantments.Enchantment;
 
 /**
- * Loads and provides access to shop configuration (items and upgrades).
+ * Loads and provides access to item shop configuration.
  */
 public final class ShopConfig {
   private final BedwarsPlugin plugin;
-  private final Map<String, Material> currencies = new HashMap<>();
   private final Map<ShopCategory, List<ShopItem>> items = new EnumMap<>(ShopCategory.class);
-
-  public static final class UpgradeDef {
-    public final List<Map<Material,Integer>> costs;
-    public final int maxLevel;
-    public final String name;
-    public UpgradeDef(List<Map<Material,Integer>> costs, int maxLevel, String name) {
-      this.costs = costs; this.maxLevel = maxLevel; this.name = name;
-    }
-  }
-  private final Map<UpgradeType, UpgradeDef> upgrades = new EnumMap<>(UpgradeType.class);
-
-  public static final class TrapDef {
-    public final Map<Material,Integer> cost;
-    public final String name;
-    public TrapDef(Map<Material,Integer> cost, String name) {
-      this.cost = cost; this.name = name;
-    }
-  }
-  private final Map<TrapType, TrapDef> traps = new EnumMap<>(TrapType.class);
 
   public ShopConfig(BedwarsPlugin plugin) {
     this.plugin = plugin;
     load();
   }
 
-  private void load() {
+  public void load() {
+    items.clear();
     File f = new File(plugin.getDataFolder(), "shop.yml");
     if (!f.exists()) plugin.saveResource("shop.yml", false);
     YamlConfiguration y = YamlConfiguration.loadConfiguration(f);
 
-    ConfigurationSection cur = y.getConfigurationSection("currencies");
-    if (cur != null) {
-      for (String k : cur.getKeys(false)) {
-        Material m = Material.matchMaterial(cur.getString(k, ""));
-        if (m != null) currencies.put(k.toUpperCase(Locale.ROOT), m);
-      }
-    }
-
-    ConfigurationSection itemsSec = y.getConfigurationSection("items");
-    if (itemsSec != null) {
-      for (String catKey : itemsSec.getKeys(false)) {
-        ShopCategory cat;
-        try { cat = ShopCategory.valueOf(catKey); } catch (IllegalArgumentException ex) { continue; }
-        List<ShopItem> list = new ArrayList<>();
-        for (Map<?,?> map : itemsSec.getMapList(catKey)) {
-          String id = String.valueOf(map.get("id"));
-          String matStr = String.valueOf(map.get("mat"));
-
-          ShopItem.Builder b = ShopItem.builder()
-              .id(id)
-              .amount(map.containsKey("amount") ? ((Number) map.get("amount")).intValue() : 1)
-              .name(map.containsKey("name") ? String.valueOf(map.get("name")) : "");
-
-          if ("WOOL_TEAM".equalsIgnoreCase(matStr)) {
-            b.mat(Material.WHITE_WOOL).teamColored(true);
-          } else {
-            Material mat = Material.matchMaterial(matStr);
-            if (mat != null) b.mat(mat);
+    ConfigurationSection cats = y.getConfigurationSection("categories");
+    if (cats == null) return;
+    for (String cKey : cats.getKeys(false)) {
+      ShopCategory cat;
+      try { cat = ShopCategory.valueOf(cKey.toUpperCase(Locale.ROOT)); }
+      catch (IllegalArgumentException ex) { continue; }
+      List<ShopItem> list = new ArrayList<>();
+      for (Map<?,?> raw : cats.getMapList(cKey)) {
+        String id = String.valueOf(raw.get("id"));
+        String name = String.valueOf(raw.get("name"));
+        String matStr = String.valueOf(raw.get("material"));
+        int amount = raw.containsKey("amount") ? ((Number)raw.get("amount")).intValue() : 1;
+        boolean teamCol = Boolean.parseBoolean(String.valueOf(raw.getOrDefault("team_colored", false)));
+        boolean perm = Boolean.parseBoolean(String.valueOf(raw.getOrDefault("permanent", false)));
+        ConfigurationSection costSec = null;
+        Object costObj = raw.get("cost");
+        Currency currency = Currency.IRON;
+        int cost = 0;
+        if (costObj instanceof Map<?,?> map) {
+          Object cur = map.get("currency");
+          Object amt = map.get("amount");
+          if (cur != null) {
+            try { currency = Currency.valueOf(String.valueOf(cur).toUpperCase(Locale.ROOT)); } catch (Exception ignore) {}
           }
-
-          Map<Material,Integer> price = parseCost(castMap(map.get("price")));
-          for (var e : price.entrySet()) {
-            b.price(e.getKey(), e.getValue());
-          }
-
-          Object enSec = map.get("enchants");
-          if (enSec instanceof Map<?,?> m2) {
-            for (var e : m2.entrySet()) {
-              Enchantment en = Enchantment.getByName(String.valueOf(e.getKey()));
-              if (en != null) b.enchant(en, ((Number) e.getValue()).intValue());
-            }
-          }
-
-          list.add(b.build());
+          if (amt instanceof Number) cost = ((Number)amt).intValue();
         }
-        items.put(cat, list);
-      }
-    }
 
-    ConfigurationSection upSec = y.getConfigurationSection("upgrades");
-    if (upSec != null) {
-      for (String upKey : upSec.getKeys(false)) {
-        if (upKey.equalsIgnoreCase("TRAPS")) {
-          ConfigurationSection tSec = upSec.getConfigurationSection(upKey);
-          if (tSec != null) {
-            for (String t : tSec.getKeys(false)) {
-              TrapType tt;
-              try { tt = TrapType.valueOf(t.toUpperCase(Locale.ROOT)); } catch (Exception ex) { continue; }
-              ConfigurationSection sec = tSec.getConfigurationSection(t);
-              if (sec == null) continue;
-              Map<Material,Integer> cost = parseCost(sec.getConfigurationSection("cost"));
-              String name = sec.getString("name", t);
-              traps.put(tt, new TrapDef(cost, name));
-            }
-          }
+        ShopItem.Builder b = ShopItem.builder().id(id).name(name).amount(amount)
+            .currency(currency).cost(cost).teamColored(teamCol).permanent(perm);
+        if ("WOOL_TEAM".equalsIgnoreCase(matStr)) {
+          b.mat(Material.WHITE_WOOL).teamColored(true);
         } else {
-          UpgradeType type;
-          try { type = UpgradeType.valueOf(upKey); } catch (IllegalArgumentException ex) { continue; }
-          ConfigurationSection sec = upSec.getConfigurationSection(upKey);
-          if (sec == null) continue;
-          String name = sec.getString("name", upKey);
-          int max = sec.getInt("maxLevel", 0);
-          List<Map<Material,Integer>> costs = new ArrayList<>();
-          if (sec.isConfigurationSection("cost")) {
-            costs.add(parseCost(sec.getConfigurationSection("cost")));
-          }
-          for (Map<?,?> m : sec.getMapList("costs")) {
-            costs.add(parseCost(castMap(m)));
-          }
-          if (max == 0) max = costs.size();
-          upgrades.put(type, new UpgradeDef(costs, max, name));
+          Material m = Material.matchMaterial(matStr);
+          if (m != null) b.mat(m);
         }
+        Object enchObj = raw.get("enchants");
+        if (enchObj instanceof Map<?,?> emap) {
+          for (var e : emap.entrySet()) {
+            Enchantment en = Enchantment.getByName(String.valueOf(e.getKey()));
+            if (en != null) b.enchant(en, ((Number)e.getValue()).intValue());
+          }
+        }
+        list.add(b.build());
       }
+      items.put(cat, list);
     }
-  }
-
-  private Map<Material,Integer> parseCost(ConfigurationSection sec) {
-    if (sec == null) return Map.of();
-    Map<Material,Integer> m = new EnumMap<>(Material.class);
-    for (String k : sec.getKeys(false)) {
-      Material mat = currencies.get(k.toUpperCase(Locale.ROOT));
-      if (mat != null) m.put(mat, sec.getInt(k));
-    }
-    return m;
-  }
-
-  private Map<Material,Integer> parseCost(Map<String,Object> raw) {
-    if (raw == null) return Map.of();
-    Map<Material,Integer> m = new EnumMap<>(Material.class);
-    for (var e : raw.entrySet()) {
-      Material mat = currencies.get(e.getKey().toUpperCase(Locale.ROOT));
-      if (mat != null) m.put(mat, ((Number)e.getValue()).intValue());
-    }
-    return m;
-  }
-
-  @SuppressWarnings("unchecked")
-  private Map<String,Object> castMap(Object o) {
-    if (o instanceof Map<?,?> map) {
-      Map<String,Object> res = new LinkedHashMap<>();
-      for (var e : map.entrySet()) {
-        res.put(String.valueOf(e.getKey()), e.getValue());
-      }
-      return res;
-    }
-    return new LinkedHashMap<>();
   }
 
   public List<ShopItem> items(ShopCategory cat) {
     return items.getOrDefault(cat, List.of());
   }
-
-  public UpgradeDef upgrade(UpgradeType t) { return upgrades.get(t); }
-  public TrapDef trap(TrapType t) { return traps.get(t); }
 }
+

--- a/src/main/java/com/example/bedwars/shop/ShopItem.java
+++ b/src/main/java/com/example/bedwars/shop/ShopItem.java
@@ -3,58 +3,74 @@ package com.example.bedwars.shop;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
 
+/**
+ * Definition of an item sold in the item shop.
+ */
 public final class ShopItem {
   public final String id;
   public final Material mat;
   public final int amount;
-  public final Map<Material, Integer> price;
+  public final Currency currency;
+  public final int cost;
   public final Map<Enchantment, Integer> enchants;
   public final String name;
   public final boolean teamColored;
+  public final boolean permanent;
 
   private ShopItem(
       String id,
       Material mat,
       int amount,
-      Map<Material, Integer> price,
+      Currency currency,
+      int cost,
       Map<Enchantment, Integer> enchants,
       String name,
-      boolean teamColored) {
+      boolean teamColored,
+      boolean permanent) {
 
     this.id = Objects.requireNonNull(id, "id");
     this.mat = Objects.requireNonNull(mat, "mat");
     this.amount = Math.max(1, amount);
-    this.price = Collections.unmodifiableMap(new LinkedHashMap<>(Objects.requireNonNull(price, "price")));
+    this.currency = Objects.requireNonNull(currency, "currency");
+    this.cost = Math.max(0, cost);
     this.enchants = Collections.unmodifiableMap(new LinkedHashMap<>(Objects.requireNonNull(enchants, "enchants")));
     this.name = Objects.requireNonNullElse(name, "");
     this.teamColored = teamColored;
+    this.permanent = permanent;
   }
 
   // ---------- Builder ----------
   public static Builder builder() { return new Builder(); }
 
   public static final class Builder {
-    private String id;                                    // OBLIGATOIRE
-    private Material mat = Material.STONE;                // défaut
-    private int amount = 1;                               // défaut
-    private final Map<Material, Integer> price = new LinkedHashMap<>();
+    private String id;                                    // required
+    private Material mat = Material.STONE;                // default
+    private int amount = 1;                               // default
+    private Currency currency = Currency.IRON;            // default
+    private int cost = 0;                                 // default
     private final Map<Enchantment, Integer> enchants = new LinkedHashMap<>();
     private String name = "";
     private boolean teamColored = false;
+    private boolean permanent = false;
 
     public Builder id(String id) { this.id = id; return this; }
     public Builder mat(Material m) { this.mat = m; return this; }
     public Builder amount(int a) { this.amount = a; return this; }
-    public Builder price(Material currency, int qty) { this.price.put(currency, qty); return this; }
+    public Builder currency(Currency c) { this.currency = c; return this; }
+    public Builder cost(int c) { this.cost = c; return this; }
     public Builder enchant(Enchantment e, int lvl) { this.enchants.put(e, lvl); return this; }
     public Builder name(String n) { this.name = n; return this; }
     public Builder teamColored(boolean yes) { this.teamColored = yes; return this; }
+    public Builder permanent(boolean yes) { this.permanent = yes; return this; }
 
     public ShopItem build() {
       if (id == null || id.isBlank()) throw new IllegalStateException("ShopItem id is required");
-      return new ShopItem(id, mat, amount, price, enchants, name, teamColored);
+      return new ShopItem(id, mat, amount, currency, cost, enchants, name, teamColored, permanent);
     }
   }
 }

--- a/src/main/java/com/example/bedwars/shop/TeamUpgradesMenu.java
+++ b/src/main/java/com/example/bedwars/shop/TeamUpgradesMenu.java
@@ -3,7 +3,6 @@ package com.example.bedwars.shop;
 import com.example.bedwars.BedwarsPlugin;
 import com.example.bedwars.arena.TeamColor;
 import com.example.bedwars.arena.TeamData;
-import java.util.Map;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -12,6 +11,10 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+
+import com.example.bedwars.shop.TeamUpgradesState;
+import com.example.bedwars.shop.UpgradeType;
+import com.example.bedwars.shop.TrapType;
 
 /**
  * GUI for team upgrades purchased with diamonds.
@@ -45,17 +48,16 @@ public final class TeamUpgradesMenu {
   }
 
   private ItemStack icon(Material mat, UpgradeType type, int level, Player p) {
-    ShopConfig.UpgradeDef def = plugin.shopConfig().upgrade(type);
+    UpgradeService.UpgradeDef def = plugin.upgrades().def(type);
     ItemStack it = new ItemStack(mat);
     ItemMeta im = it.getItemMeta();
     if (im != null && def != null) {
-      im.setDisplayName(ChatColor.AQUA + type.name() + " " + level + "/" + def.maxLevel);
-      if (level < def.maxLevel) {
-        Map<Material,Integer> costMap = def.costs.get(Math.min(level, def.costs.size()-1));
-        int cost = costMap.getOrDefault(Material.DIAMOND, 0);
+      im.setDisplayName(ChatColor.AQUA + type.name() + " " + level + "/" + def.max);
+      if (level < def.max) {
+        int cost = def.perLevel ? def.costDiamond * (level + 1) : def.costDiamond;
         int have = plugin.upgrades().countDiamonds(p);
         ChatColor col = have >= cost ? ChatColor.GRAY : ChatColor.RED;
-        im.setLore(java.util.List.of(col + "Coût : ♦ " + cost + " Diamant(s)"));
+        im.setLore(java.util.List.of(col + "Coût : " + cost + "◆"));
       } else {
         im.setLore(java.util.List.of(ChatColor.GRAY + plugin.messages().get("shop.maxed")));
       }
@@ -65,15 +67,15 @@ public final class TeamUpgradesMenu {
   }
 
   private ItemStack trapIcon(TeamUpgradesState st, Player p) {
-    ShopConfig.TrapDef def = plugin.shopConfig().trap(TrapType.ALARM);
+    UpgradeService.TrapDef def = plugin.upgrades().trapDef(TrapType.ALARM);
     ItemStack it = new ItemStack(Material.TRIPWIRE_HOOK);
     ItemMeta im = it.getItemMeta();
     if (im != null && def != null) {
       im.setDisplayName(ChatColor.LIGHT_PURPLE + "Traps " + st.trapQueue().size() + "/3");
-      int cost = def.cost.getOrDefault(Material.DIAMOND, 0);
+      int cost = def.costDiamond;
       int have = plugin.upgrades().countDiamonds(p);
       ChatColor col = have >= cost ? ChatColor.GRAY : ChatColor.RED;
-      im.setLore(java.util.List.of(col + "Coût : ♦ " + cost + " Diamant(s)"));
+      im.setLore(java.util.List.of(col + "Coût : " + cost + "◆"));
       it.setItemMeta(im);
     }
     return it;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -54,8 +54,13 @@ drops:
   EMERALD: EMERALD
 holograms:
   enabled: true
+  types:
+    TEAM_IRON: false
+    TEAM_GOLD: false
+    DIAMOND: true
+    EMERALD: true
   line_1: "&b{type} &7T{tier}"
-  line_2: "&f{cooldown}s &7(Cap {count}/{cap})"
+  line_2: "&f{cooldown}s"
   y_offset: 1.7
 paper_tuning:
   merge_radius_item: 2.5

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -83,10 +83,9 @@ shop:
   title: "&8Boutique &7({cat})"
   upgrades-title: "&8Améliorations d'équipe"
   no-context: "&cVous devez être dans une arène et une équipe."
-  bought: "&aAchat: &f{item}"
-  not-enough: "&cRessources insuffisantes: &f{cost}"
+  need: "&cIl manque &f{amount}&7x {currency}."
+  bought: "&aAchat effectué: &f{item}."
   maxed: "&7Déjà au niveau maximal."
-  applied: "&aAmélioration appliquée: &f{name}"
   trap-added: "&aPiège ajouté. File: {count}/3"
 
 game:
@@ -114,3 +113,7 @@ gens:
   emerald_t2: "&aÉmeraude II &7→ Générateurs émeraude accélérés !"
   emerald_t3: "&aÉmeraude III &7→ Vitesse maximale émeraude !"
   cap_reached: "&7Cap atteint: &f{type} &7({count}/{cap}). Videz le pad !"
+
+upgrades:
+  need_diamond: "&cIl faut &b{cost}◆ diamants."
+  bought: "&aAmélioration achetée: &f{name}."

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -1,66 +1,89 @@
-currencies:
-  IRON: IRON_INGOT
-  GOLD: GOLD_INGOT
-  DIAMOND: DIAMOND
-  EMERALD: EMERALD
-
-items:
-  BLOCKS:
-    - id: "wool_16"
-      mat: "WOOL_TEAM"
+categories:
+  blocks:
+    - id: WOOL_TEAM
+      name: "&fLaine (&7équipe&f) ×16"
+      material: WHITE_WOOL
+      team_colored: true
+      cost: { currency: IRON, amount: 4 }
       amount: 16
-      price: { GOLD: 4 }
-      name: "&fLaine (&7{team}&f) x16"
-    - id: "glass_4"
-      mat: "WHITE_STAINED_GLASS"
+    - id: GLASS_BLAST
+      name: "&fVerre anti-explosion ×4"
+      material: GLASS
+      cost: { currency: IRON, amount: 12 }
       amount: 4
-      price: { IRON: 12 }
-      name: "&fVerre renforcé x4"
+    - id: END_STONE
+      name: "&fEndstone ×12"
+      material: END_STONE
+      cost: { currency: IRON, amount: 24 }
+      amount: 12
 
-  MELEE:
-    - id: "stone_sword"
-      mat: "STONE_SWORD"
-      enchants: { SHARPNESS: 1 }
-      price: { IRON: 10 }
+  melee:
+    - id: STONE_SWORD
       name: "&fÉpée en pierre"
+      material: STONE_SWORD
+      cost: { currency: IRON, amount: 10 }
+    - id: IRON_SWORD
+      name: "&fÉpée en fer"
+      material: IRON_SWORD
+      cost: { currency: GOLD, amount: 7 }
+    - id: DIAMOND_SWORD
+      name: "&bÉpée en diamant"
+      material: DIAMOND_SWORD
+      cost: { currency: EMERALD, amount: 4 }
 
-  ARMOR:
-    - id: "permanent_iron_armor"
-      mat: "IRON_BOOTS"
-      price: { GOLD: 12 }
-      name: "&fArmure permanente : &7maille→fer"
+  armor:
+    - id: CHAINMAIL_PERM
+      name: "&7Cotte (&operma&7)"
+      material: CHAINMAIL_BOOTS
+      permanent: true
+      cost: { currency: IRON, amount: 30 }
+    - id: IRON_ARMOR_PERM
+      name: "&fArmure fer (&operma&f)"
+      material: IRON_BOOTS
+      permanent: true
+      cost: { currency: GOLD, amount: 12 }
+    - id: DIAMOND_ARMOR_PERM
+      name: "&bArmure diamant (&operma&b)"
+      material: DIAMOND_BOOTS
+      permanent: true
+      cost: { currency: EMERALD, amount: 6 }
 
-  TOOLS:
-    - id: "shears"
-      mat: "SHEARS"
-      price: { IRON: 20 }
-      name: "&fCisailles"
+  tools:
+    - id: SHEARS_PERM
+      name: "&fCisailles (&operma&f)"
+      material: SHEARS
+      permanent: true
+      cost: { currency: IRON, amount: 20 }
+    - id: PICK_WOOD
+      name: "&fPioche I"
+      material: WOODEN_PICKAXE
+      cost: { currency: IRON, amount: 10 }
+    - id: AXE_WOOD
+      name: "&fHache I"
+      material: WOODEN_AXE
+      cost: { currency: IRON, amount: 10 }
 
-  UTILITY:
-    - id: "tnt"
-      mat: "TNT"
-      amount: 1
-      price: { GOLD: 8 }
+  ranged:
+    - id: BOW_BASIC
+      name: "&fArc"
+      material: BOW
+      cost: { currency: GOLD, amount: 12 }
+    - id: ARROW_X8
+      name: "&fFlèches ×8"
+      material: ARROW
+      amount: 8
+      cost: { currency: GOLD, amount: 2 }
+
+  utility:
+    - id: FIREBALL
+      name: "&fBoule de feu"
+      material: FIRE_CHARGE
+      cost: { currency: IRON, amount: 40 }
+    - id: TNT
       name: "&fTNT"
-
-upgrades:
-  SHARPNESS:
-    cost: { DIAMOND: 4 }
-    maxLevel: 1
-    name: "&bAffûtage (Sharpness I)"
-  PROTECTION:
-    costs: [ {DIAMOND:2}, {DIAMOND:4}, {DIAMOND:6}, {DIAMOND:8} ]
-    name: "&bProtection d'équipe {level}"
-  MANIC_MINER:
-    costs: [ {DIAMOND:2}, {DIAMOND:4} ]
-    name: "&bManic Miner {level}"
-  HEAL_POOL:
-    cost: { DIAMOND: 3 }
-    name: "&bHeal Pool"
-  FORGE:
-    costs: [ {DIAMOND:2}, {DIAMOND:4}, {DIAMOND:6}, {DIAMOND:8} ]
-    name: "&bForge {level}"
-  TRAPS:
-    alarm:
-      cost: { DIAMOND: 1 }
-      name: "&dPiège: Alarme"
+      material: TNT
+      cost: { currency: GOLD, amount: 4 }
+    - id: ENDER_PEARL
+      name: "&bPerle"
+      material: ENDER_PEARL
+      cost: { currency: EMERALD, amount: 4 }

--- a/src/main/resources/upgrades.yml
+++ b/src/main/resources/upgrades.yml
@@ -1,0 +1,6 @@
+upgrades:
+  sharpness:   { cost_diamond: 4, max: 1, name: "&bAffûtage" }
+  protection:  { cost_diamond: 2, per_level: true, max: 4, name: "&bProtection {level}" }
+  manic_miner: { cost_diamond: 2, per_level: true, max: 2, name: "&bHâte {level}" }
+  forge:       { cost_diamond: 2, per_level: true, max: 4, name: "&bForge {level}" }
+  trap_alarm:  { cost_diamond: 1, name: "&dPiège: Alarme" }


### PR DESCRIPTION
## Summary
- show holograms only for diamond and emerald generators with tier & cooldown
- add currency-based item shop and diamond-only upgrades
- configure shop, upgrades, and messages for Hypixel-like economy

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c6ae44400832986ba8e7b2b76318c