### PR TITLE
Fix build rules, TNT and lobby items for Bedwars

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -19,6 +19,9 @@ import com.example.bedwars.listeners.DamageRulesListener;
 import com.example.bedwars.listeners.EntityExplodeListener;
 import com.example.bedwars.listeners.PlayerDeathListener;
 import com.example.bedwars.listeners.PlayerRespawnListener;
+import com.example.bedwars.listeners.TntListener;
+import com.example.bedwars.lobby.LobbyItemsService;
+import com.example.bedwars.lobby.LobbyListener;
 import com.example.bedwars.setup.PromptService;
 import com.example.bedwars.shop.ShopConfig;
 import com.example.bedwars.shop.UpgradeService;
@@ -52,6 +55,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   private GameService gameService;
   private BuildRulesService buildRules;
   private DeathRespawnService deathService;
+  private LobbyItemsService lobbyItems;
 
   @Override
   public void onEnable() {
@@ -69,7 +73,8 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.kitService = new KitService(this);
     this.spectatorService = new SpectatorService();
     this.gameMessages = new GameMessages(this, contextService);
-    this.gameService = new GameService(this, contextService, teamAssignment, kitService, spectatorService, gameMessages);
+    this.lobbyItems = new LobbyItemsService(this);
+    this.gameService = new GameService(this, contextService, teamAssignment, kitService, spectatorService, gameMessages, lobbyItems);
     this.deathService = new DeathRespawnService(this, contextService, kitService, spectatorService, gameMessages, gameService);
     this.gameService.setDeathService(deathService);
     this.upgradeService = new UpgradeService(this, contextService);
@@ -93,6 +98,8 @@ public final class BedwarsPlugin extends JavaPlugin {
     getServer().getPluginManager().registerEvents(new BlockRulesListener(this, contextService, buildRules), this);
     getServer().getPluginManager().registerEvents(new DamageRulesListener(this, contextService), this);
     getServer().getPluginManager().registerEvents(new EntityExplodeListener(buildRules), this);
+    getServer().getPluginManager().registerEvents(new TntListener(this, contextService, buildRules), this);
+    getServer().getPluginManager().registerEvents(new LobbyListener(this, lobbyItems, contextService), this);
 
     getLogger().info("Bedwars loaded.");
   }

--- a/src/main/java/com/example/bedwars/game/GameService.java
+++ b/src/main/java/com/example/bedwars/game/GameService.java
@@ -24,18 +24,21 @@ public final class GameService {
   private final KitService kit;
   private final SpectatorService spectator;
   private final GameMessages messages;
+  private final com.example.bedwars.lobby.LobbyItemsService lobbyItems;
   private DeathRespawnService deathService;
   private final Map<String, Integer> countdownTasks = new HashMap<>();
   private final Map<String, Integer> timerTasks = new HashMap<>();
 
   public GameService(BedwarsPlugin plugin, PlayerContextService ctx, TeamAssignment ta,
-                     KitService kit, SpectatorService spec, GameMessages msgs) {
+                     KitService kit, SpectatorService spec, GameMessages msgs,
+                     com.example.bedwars.lobby.LobbyItemsService lobbyItems) {
     this.plugin = plugin;
     this.contexts = ctx;
     this.teamAssignment = ta;
     this.kit = kit;
     this.spectator = spec;
     this.messages = msgs;
+    this.lobbyItems = lobbyItems;
   }
 
   public void setDeathService(DeathRespawnService drs) { this.deathService = drs; }
@@ -69,6 +72,7 @@ public final class GameService {
     contexts.join(p, arenaId);
     p.getInventory().clear();
     if (a.lobby() != null) p.teleport(a.lobby());
+    lobbyItems.giveLobbyItems(p);
     messages.send(p, "game.join", Map.of("arena", arenaId));
     // auto assign
     TeamColor team = teamAssignment.assign(a, p);

--- a/src/main/java/com/example/bedwars/listeners/BedListener.java
+++ b/src/main/java/com/example/bedwars/listeners/BedListener.java
@@ -13,6 +13,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.PlayerBedEnterEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 
 /** Handles bed breaking events. */
 public final class BedListener implements Listener {
@@ -22,6 +24,18 @@ public final class BedListener implements Listener {
 
   public BedListener(BedwarsPlugin plugin, GameService game, PlayerContextService ctx) {
     this.plugin = plugin; this.game = game; this.ctx = ctx;
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onBedEnter(PlayerBedEnterEvent e) {
+    e.setCancelled(true);
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onInteract(PlayerInteractEvent e) {
+    if (e.getClickedBlock() != null && Tag.BEDS.isTagged(e.getClickedBlock().getType())) {
+      e.setCancelled(true);
+    }
   }
 
   @EventHandler(ignoreCancelled = true)
@@ -45,7 +59,7 @@ public final class BedListener implements Listener {
 
     TeamColor playerTeam = ctx.getTeam(p);
     if (bedTeam == playerTeam) {
-      p.sendMessage("§cC’est votre lit !");
+      p.sendMessage(plugin.messages().get("prefix") + plugin.messages().get("game.bed-own"));
       e.setCancelled(true);
       return;
     }

--- a/src/main/java/com/example/bedwars/listeners/BlockRulesListener.java
+++ b/src/main/java/com/example/bedwars/listeners/BlockRulesListener.java
@@ -53,7 +53,7 @@ public final class BlockRulesListener implements Listener {
     Arena a = plugin.arenas().get(arenaId).orElse(null);
     if (a == null || !allowedStates.contains(a.state())) { e.setCancelled(true); return; }
     Block b = e.getBlock();
-    if (Tag.BEDS.isTagged(b.getType())) { e.setCancelled(true); return; }
+    if (Tag.BEDS.isTagged(b.getType())) { return; }
     if (plugin.getConfig().getBoolean("rules.break-only-placed", true) && !buildRules.wasPlaced(arenaId, b.getLocation())) {
       e.setCancelled(true);
     } else {

--- a/src/main/java/com/example/bedwars/listeners/PlayerDeathListener.java
+++ b/src/main/java/com/example/bedwars/listeners/PlayerDeathListener.java
@@ -3,6 +3,7 @@ package com.example.bedwars.listeners;
 import com.example.bedwars.BedwarsPlugin;
 import com.example.bedwars.game.DeathRespawnService;
 import com.example.bedwars.game.PlayerContextService;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -31,6 +32,7 @@ public final class PlayerDeathListener implements Listener {
     Player p = e.getEntity();
     if (ctx.getArena(p) == null) return;
     death.handleDeath(p);
+    Bukkit.getScheduler().runTask(plugin, () -> p.spigot().respawn());
   }
 
   @EventHandler

--- a/src/main/java/com/example/bedwars/listeners/TntListener.java
+++ b/src/main/java/com/example/bedwars/listeners/TntListener.java
@@ -1,0 +1,43 @@
+package com.example.bedwars.listeners;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.GameState;
+import com.example.bedwars.game.PlayerContextService;
+import com.example.bedwars.services.BuildRulesService;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+/** Auto-primes TNT placed by players. */
+public final class TntListener implements Listener {
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService ctx;
+  private final BuildRulesService buildRules;
+
+  public TntListener(BedwarsPlugin plugin, PlayerContextService ctx, BuildRulesService br) {
+    this.plugin = plugin; this.ctx = ctx; this.buildRules = br;
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onPlaceTnt(BlockPlaceEvent e) {
+    if (e.getBlockPlaced().getType() != Material.TNT) return;
+    Player p = e.getPlayer();
+    String arenaId = ctx.getArena(p);
+    if (arenaId == null) { e.setCancelled(true); return; }
+    Arena a = plugin.arenas().get(arenaId).orElse(null);
+    if (a == null || a.state() != GameState.RUNNING) { e.setCancelled(true); return; }
+    Location loc = e.getBlockPlaced().getLocation().add(0.5, 0, 0.5);
+    e.setCancelled(true);
+    e.getBlockPlaced().setType(Material.AIR);
+    buildRules.removePlaced(arenaId, e.getBlockPlaced().getLocation());
+    TNTPrimed t = (TNTPrimed) loc.getWorld().spawnEntity(loc, EntityType.TNT);
+    t.setFuseTicks(plugin.getConfig().getInt("tnt.fuse_ticks", 40));
+    if (plugin.getConfig().getBoolean("tnt.attribute_owner", true)) t.setSource(p);
+  }
+}

--- a/src/main/java/com/example/bedwars/lobby/LobbyItemsService.java
+++ b/src/main/java/com/example/bedwars/lobby/LobbyItemsService.java
@@ -1,0 +1,47 @@
+package com.example.bedwars.lobby;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/** Provides lobby items like team selector and leave item. */
+public final class LobbyItemsService {
+  private final BedwarsPlugin plugin;
+  private final ItemStack teamSelector;
+  private final ItemStack leaveItem;
+
+  public LobbyItemsService(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+    this.teamSelector = createItem("lobby.team_selector");
+    this.leaveItem = createItem("lobby.leave_item");
+  }
+
+  private ItemStack createItem(String path) {
+    String mat = plugin.getConfig().getString(path + ".material", "COMPASS");
+    Material m = Material.matchMaterial(mat);
+    if (m == null) m = Material.COMPASS;
+    String name = ChatColor.translateAlternateColorCodes('&',
+        plugin.getConfig().getString(path + ".name", ""));
+    ItemStack it = new ItemStack(m);
+    ItemMeta meta = it.getItemMeta();
+    if (meta != null) { meta.setDisplayName(name); it.setItemMeta(meta); }
+    return it;
+  }
+
+  public void giveLobbyItems(Player p) {
+    p.getInventory().clear();
+    p.getInventory().setItem(0, teamSelector.clone());
+    p.getInventory().setItem(8, leaveItem.clone());
+  }
+
+  public boolean isTeamSelector(ItemStack it) {
+    return it != null && it.isSimilar(teamSelector);
+  }
+
+  public boolean isLeaveItem(ItemStack it) {
+    return it != null && it.isSimilar(leaveItem);
+  }
+}

--- a/src/main/java/com/example/bedwars/lobby/LobbyListener.java
+++ b/src/main/java/com/example/bedwars/lobby/LobbyListener.java
@@ -1,0 +1,101 @@
+package com.example.bedwars.lobby;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.TeamColor;
+import com.example.bedwars.arena.TeamData;
+import com.example.bedwars.game.PlayerContextService;
+import java.util.ArrayList;
+import java.util.List;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/** Handles lobby items interactions. */
+public final class LobbyListener implements Listener {
+  private final BedwarsPlugin plugin;
+  private final LobbyItemsService items;
+  private final PlayerContextService ctx;
+
+  public LobbyListener(BedwarsPlugin plugin, LobbyItemsService items, PlayerContextService ctx) {
+    this.plugin = plugin; this.items = items; this.ctx = ctx;
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onInteract(PlayerInteractEvent e) {
+    ItemStack it = e.getItem();
+    if (it == null) return;
+    if (items.isTeamSelector(it)) {
+      openTeamSelectMenu(e.getPlayer());
+      e.setCancelled(true);
+    } else if (items.isLeaveItem(it)) {
+      plugin.game().leave(e.getPlayer(), true);
+      e.setCancelled(true);
+    }
+  }
+
+  private void openTeamSelectMenu(Player p) {
+    String arenaId = ctx.getArena(p);
+    if (arenaId == null) return;
+    Arena a = plugin.arenas().get(arenaId).orElse(null);
+    if (a == null) return;
+    Inventory inv = Bukkit.createInventory(null, 9, plugin.messages().get("game.choose-team-title"));
+    int i = 0;
+    for (TeamColor tc : TeamColor.values()) {
+      ItemStack icon;
+      if (!a.enabledTeams().contains(tc)) {
+        icon = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+      } else {
+        TeamData td = a.team(tc);
+        int count = ctx.countPlayers(arenaId, tc);
+        if (count >= td.maxPlayers()) {
+          icon = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        } else {
+          icon = new ItemStack(tc.wool);
+        }
+        ItemMeta meta = icon.getItemMeta();
+        if (meta != null) {
+          meta.setDisplayName(tc.color + tc.display);
+          List<String> lore = new ArrayList<>();
+          lore.add("§7" + count + "/" + td.maxPlayers() + " joueurs");
+          meta.setLore(lore);
+          icon.setItemMeta(meta);
+        }
+      }
+      inv.setItem(i++, icon);
+    }
+    p.openInventory(inv);
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onInventoryClick(InventoryClickEvent e) {
+    if (!(e.getWhoClicked() instanceof Player p)) return;
+    if (!plugin.messages().get("game.choose-team-title").equals(e.getView().getTitle())) return;
+    e.setCancelled(true);
+    ItemStack clicked = e.getCurrentItem();
+    if (clicked == null) return;
+    String arenaId = ctx.getArena(p);
+    if (arenaId == null) return;
+    Arena a = plugin.arenas().get(arenaId).orElse(null);
+    if (a == null) return;
+    for (TeamColor tc : TeamColor.values()) {
+      if (clicked.getType() == tc.wool) {
+        TeamData td = a.team(tc);
+        int count = ctx.countPlayers(arenaId, tc);
+        if (count >= td.maxPlayers()) return; // full
+        ctx.setTeam(p, tc);
+        p.sendMessage(plugin.messages().get("prefix") +
+            plugin.messages().format("game.assign-team", java.util.Map.of("team", tc.display)));
+        p.closeInventory();
+        return;
+      }
+    }
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -78,7 +78,12 @@ rules:
   break-only-enemy-bed: true
   protect-map: true
   break-only-placed: true
-  place-allow: [WHITE_WOOL, GLASS, LADDER, TNT]
+  place-allow:
+    - WHITE_WOOL
+    - GLASS
+    - END_STONE
+    - LADDER
+    - TNT
   allow-build-states: [RUNNING]
 
 respawn:
@@ -88,3 +93,15 @@ respawn:
 kit:
   give_compass_on_spawn: false
   give_blocks_on_spawn: false
+
+tnt:
+  fuse_ticks: 40
+  attribute_owner: true
+
+lobby:
+  team_selector:
+    material: COMPASS
+    name: "&aSélecteur d'équipe"
+  leave_item:
+    material: BARRIER
+    name: "&cQuitter l'arène"

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -100,6 +100,7 @@ game:
   choose-team-title: "&8Choisissez votre &lÉquipe"
   bed-destroyed: "&cLe lit de {team} &ca été détruit par {player} !"
   bed-destroyed-you: "&cVotre lit a été détruit ! Dernière vie."
+  bed-own: "&cC'est votre lit !"
   eliminated: "&c{player} a été éliminé."
   victory: "&6Victoire de l'équipe {team} !"
   respawn-in: "&eRespawn dans &6{sec}s"


### PR DESCRIPTION
## Summary
- Allow whitelisted block placement and tracking; prevent map damage and own bed interaction
- Auto-respawn players into spectator mode and prime TNT on placement
- Add arena lobby items for team selection and leaving

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c7b2cead88329a224ac14a58d2702