### PR TITLE
feat: apply team upgrades to equipment

### DIFF
--- a/src/main/java/com/example/bedwars/game/DeathRespawnService.java
+++ b/src/main/java/com/example/bedwars/game/DeathRespawnService.java
@@ -71,7 +71,7 @@ public final class DeathRespawnService {
         spectator.fromSpectator(p);
         p.setGameMode(org.bukkit.GameMode.SURVIVAL);
         kit.giveRespawnKit(p, team);
-        plugin.upgrades().applySharpness(arenaId, team);
+        if (td.upgrades().sharpness()) plugin.upgrades().applySharpness(arenaId, team);
         plugin.upgrades().applyProtection(arenaId, team, td.upgrades().protection());
         plugin.upgrades().applyManicMiner(arenaId, team, td.upgrades().manicMiner());
         p.sendMessage(plugin.messages().get("respawn.respawned"));

--- a/src/main/java/com/example/bedwars/game/GameService.java
+++ b/src/main/java/com/example/bedwars/game/GameService.java
@@ -137,7 +137,7 @@ public final class GameService {
       Location spawn = td.spawn();
       if (spawn != null) p.teleport(spawn);
       kit.giveStartKit(p, team);
-      plugin.upgrades().applySharpness(a.id(), team);
+      if (td.upgrades().sharpness()) plugin.upgrades().applySharpness(a.id(), team);
       plugin.upgrades().applyProtection(a.id(), team, td.upgrades().protection());
       plugin.upgrades().applyManicMiner(a.id(), team, td.upgrades().manicMiner());
       contexts.markAlive(p);

--- a/src/main/java/com/example/bedwars/game/KitService.java
+++ b/src/main/java/com/example/bedwars/game/KitService.java
@@ -2,9 +2,11 @@ package com.example.bedwars.game;
 
 import com.example.bedwars.BedwarsPlugin;
 import com.example.bedwars.arena.TeamColor;
+import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
 
 /** Simple kit handling for start and respawn. */
 public final class KitService {
@@ -21,6 +23,35 @@ public final class KitService {
     if (plugin.getConfig().getBoolean("kit.give_compass_on_spawn", false)) {
       p.getInventory().addItem(new ItemStack(Material.COMPASS));
     }
+    if (plugin.getConfig().getBoolean("armor.dye_colored", true)) {
+      p.getInventory().setHelmet(colored(Material.LEATHER_HELMET, team));
+      p.getInventory().setChestplate(colored(Material.LEATHER_CHESTPLATE, team));
+      p.getInventory().setLeggings(colored(Material.LEATHER_LEGGINGS, team));
+      p.getInventory().setBoots(colored(Material.LEATHER_BOOTS, team));
+    }
+  }
+
+  private ItemStack colored(Material type, TeamColor team) {
+    ItemStack it = new ItemStack(type);
+    var meta = (LeatherArmorMeta) it.getItemMeta();
+    if (meta != null) {
+      meta.setColor(toColor(team));
+      it.setItemMeta(meta);
+    }
+    return it;
+  }
+
+  private Color toColor(TeamColor team) {
+    return switch (team) {
+      case RED -> Color.RED;
+      case BLUE -> Color.BLUE;
+      case GREEN -> Color.GREEN;
+      case YELLOW -> Color.YELLOW;
+      case AQUA -> Color.AQUA;
+      case WHITE -> Color.WHITE;
+      case PINK -> Color.FUCHSIA;
+      case GRAY -> Color.GRAY;
+    };
   }
 
   public void giveStartKit(Player p, TeamColor team) {

--- a/src/main/java/com/example/bedwars/listeners/UpgradeApplyListener.java
+++ b/src/main/java/com/example/bedwars/listeners/UpgradeApplyListener.java
@@ -25,7 +25,11 @@ public final class UpgradeApplyListener implements Listener {
     Player p = e.getPlayer();
     String ar = ctx.getArena(p);
     TeamColor tm = ctx.getTeam(p);
-    if (ar != null && tm != null) plugin.upgrades().applySharpness(ar, tm);
+    if (ar == null || tm == null) return;
+    plugin.arenas().get(ar).ifPresent(arena -> {
+      TeamData td = arena.team(tm);
+      if (td.upgrades().sharpness()) plugin.upgrades().applySharpness(ar, tm);
+    });
   }
 
   @EventHandler
@@ -38,7 +42,7 @@ public final class UpgradeApplyListener implements Listener {
       TeamData td = arena.team(tm);
       TeamUpgradesState st = td.upgrades();
       plugin.getServer().getScheduler().runTask(plugin, () -> {
-        plugin.upgrades().applySharpness(ar, tm);
+        if (st.sharpness()) plugin.upgrades().applySharpness(ar, tm);
         plugin.upgrades().applyProtection(ar, tm, st.protection());
       });
     });

--- a/src/main/java/com/example/bedwars/shop/ShopListener.java
+++ b/src/main/java/com/example/bedwars/shop/ShopListener.java
@@ -80,7 +80,22 @@ public final class ShopListener implements Listener {
         Material mat = si.teamColored ? ih.team.wool : si.mat;
         ItemStack it = new ItemStack(mat, si.amount);
         si.enchants.forEach((en,l)-> it.addEnchantment(en,l));
-        p.getInventory().addItem(it);
+        if (mat.name().endsWith("_SWORD")) {
+          for (int i = 0; i < p.getInventory().getSize(); i++) {
+            ItemStack cur = p.getInventory().getItem(i);
+            if (cur != null && cur.getType().name().endsWith("_SWORD")) {
+              p.getInventory().setItem(i, null);
+            }
+          }
+          p.getInventory().setItemInMainHand(it);
+          plugin.arenas().get(ih.arenaId).ifPresent(arena -> {
+            if (arena.team(ih.team).upgrades().sharpness()) {
+              plugin.upgrades().applySharpness(ih.arenaId, ih.team);
+            }
+          });
+        } else {
+          p.getInventory().addItem(it);
+        }
         String name = ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', si.name.replace("{team}", ih.team.display)));
         p.sendMessage(plugin.messages().format("shop.bought", Map.of("item", name)));
       } else {

--- a/src/main/java/com/example/bedwars/shop/UpgradeService.java
+++ b/src/main/java/com/example/bedwars/shop/UpgradeService.java
@@ -84,14 +84,23 @@ public final class UpgradeService {
   }
 
   private void applySharpness(Player p) {
-    ItemStack is = p.getInventory().getItemInMainHand();
-    if (is == null) return;
-    Material m = is.getType();
-    if (!m.name().endsWith("_SWORD")) return;
-    ItemMeta meta = is.getItemMeta();
-    if (meta == null) return;
-    meta.addEnchant(Enchantment.SHARPNESS, 1, true);
-    is.setItemMeta(meta);
+    for (ItemStack is : p.getInventory().getContents()) {
+      if (is == null) continue;
+      Material m = is.getType();
+      if (!m.name().endsWith("_SWORD")) continue;
+      ItemMeta meta = is.getItemMeta();
+      if (meta == null) continue;
+      meta.addEnchant(Enchantment.SHARPNESS, 1, true);
+      is.setItemMeta(meta);
+    }
+    ItemStack off = p.getInventory().getItemInOffHand();
+    if (off != null && off.getType().name().endsWith("_SWORD")) {
+      ItemMeta meta = off.getItemMeta();
+      if (meta != null) {
+        meta.addEnchant(Enchantment.SHARPNESS, 1, true);
+        off.setItemMeta(meta);
+      }
+    }
   }
 
   private void applyProtection(Player p, int level) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -95,6 +95,9 @@ kit:
   give_compass_on_spawn: false
   give_blocks_on_spawn: false
 
+armor:
+  dye_colored: true
+
 tnt:
   fuse_ticks: 40
   attribute_owner: true


### PR DESCRIPTION
## Summary
- tint starter leather armor to team color
- only add sharpness when upgrade purchased and apply to all swords
- replace existing sword on purchase and reapply sharpness

## Testing
- `mvn -q -e -DskipTests package` *(fails: PluginResolutionException: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_689ccd5c41d08329b2f932b501116688