### PR TITLE
Improve Bedwars compass, build, and armor handling

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -16,6 +16,8 @@ import com.example.bedwars.listeners.JoinLeaveListener;
 import com.example.bedwars.listeners.BedListener;
 import com.example.bedwars.listeners.DamageRulesListener;
 import com.example.bedwars.listeners.EntityExplodeListener;
+import com.example.bedwars.listeners.CompassListener;
+import com.example.bedwars.listeners.ArmorLockListener;
 import com.example.bedwars.rules.BuildRulesListener;
 import com.example.bedwars.listeners.DeathListener;
 import com.example.bedwars.listeners.VoidFailSafeListener;
@@ -73,7 +75,7 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.shopConfig = new ShopConfig(this);
     this.contextService = new PlayerContextService();
     this.teamAssignment = new TeamAssignment(contextService);
-    this.kitService = new KitService(this);
+    this.kitService = new KitService(this, contextService);
     this.spectatorService = new SpectatorService();
     this.gameMessages = new GameMessages(this, contextService);
     this.lobbyItems = new LobbyItemsService(this);
@@ -106,6 +108,8 @@ public final class BedwarsPlugin extends JavaPlugin {
     getServer().getPluginManager().registerEvents(new TntListener(this, contextService, buildRules), this);
     getServer().getPluginManager().registerEvents(teamSelectMenu, this);
     getServer().getPluginManager().registerEvents(new LobbyListener(this, lobbyItems, teamSelectMenu, contextService, gameService), this);
+    getServer().getPluginManager().registerEvents(new CompassListener(this, contextService, teamSelectMenu), this);
+    getServer().getPluginManager().registerEvents(new ArmorLockListener(this, contextService), this);
 
     getLogger().info("Bedwars loaded.");
   }

--- a/src/main/java/com/example/bedwars/game/KitService.java
+++ b/src/main/java/com/example/bedwars/game/KitService.java
@@ -7,12 +7,16 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.persistence.PersistentDataType;
 
 /** Simple kit handling for start and respawn. */
 public final class KitService {
   private final BedwarsPlugin plugin;
+  private final PlayerContextService ctx;
 
-  public KitService(BedwarsPlugin plugin) { this.plugin = plugin; }
+  public KitService(BedwarsPlugin plugin, PlayerContextService ctx) {
+    this.plugin = plugin; this.ctx = ctx;
+  }
 
   private void giveBase(Player p, TeamColor team) {
     p.getInventory().clear();
@@ -21,14 +25,27 @@ public final class KitService {
       p.getInventory().addItem(new ItemStack(team.wool, 16));
     }
     if (plugin.getConfig().getBoolean("kit.give_compass_on_spawn", false)) {
-      p.getInventory().addItem(new ItemStack(Material.COMPASS));
+      ItemStack comp = new ItemStack(Material.COMPASS);
+      var meta = comp.getItemMeta();
+      if (meta != null) {
+        meta.getPersistentDataContainer().set(plugin.keys().BW_ITEM(), PersistentDataType.STRING, "compass");
+        comp.setItemMeta(meta);
+      }
+      p.getInventory().addItem(comp);
     }
-    if (plugin.getConfig().getBoolean("armor.dye_colored", true)) {
+    boolean dye = plugin.getConfig().getBoolean("armor.dye_colored", true);
+    if (dye) {
       p.getInventory().setHelmet(colored(Material.LEATHER_HELMET, team));
       p.getInventory().setChestplate(colored(Material.LEATHER_CHESTPLATE, team));
-      p.getInventory().setLeggings(colored(Material.LEATHER_LEGGINGS, team));
-      p.getInventory().setBoots(colored(Material.LEATHER_BOOTS, team));
     }
+    int tier;
+    if (plugin.getConfig().getBoolean("shop.armor_persistent", true)) {
+      tier = ctx.getArmorTier(p);
+    } else {
+      tier = 0;
+      ctx.setArmorTier(p, 0);
+    }
+    equipTier(p, team, tier, dye);
   }
 
   private ItemStack colored(Material type, TeamColor team) {
@@ -60,5 +77,31 @@ public final class KitService {
 
   public void giveRespawnKit(Player p, TeamColor team) {
     giveBase(p, team);
+  }
+
+  private void equipTier(Player p, TeamColor team, int tier, boolean dye) {
+    switch (tier) {
+      case 3 -> {
+        p.getInventory().setLeggings(new ItemStack(Material.DIAMOND_LEGGINGS));
+        p.getInventory().setBoots(new ItemStack(Material.DIAMOND_BOOTS));
+      }
+      case 2 -> {
+        p.getInventory().setLeggings(new ItemStack(Material.IRON_LEGGINGS));
+        p.getInventory().setBoots(new ItemStack(Material.IRON_BOOTS));
+      }
+      case 1 -> {
+        p.getInventory().setLeggings(new ItemStack(Material.CHAINMAIL_LEGGINGS));
+        p.getInventory().setBoots(new ItemStack(Material.CHAINMAIL_BOOTS));
+      }
+      default -> {
+        if (dye) {
+          p.getInventory().setLeggings(colored(Material.LEATHER_LEGGINGS, team));
+          p.getInventory().setBoots(colored(Material.LEATHER_BOOTS, team));
+        } else {
+          p.getInventory().setLeggings(new ItemStack(Material.LEATHER_LEGGINGS));
+          p.getInventory().setBoots(new ItemStack(Material.LEATHER_BOOTS));
+        }
+      }
+    }
   }
 }

--- a/src/main/java/com/example/bedwars/game/PlayerContextService.java
+++ b/src/main/java/com/example/bedwars/game/PlayerContextService.java
@@ -18,6 +18,7 @@ public final class PlayerContextService {
     private boolean alive = true;
     private boolean spectating = false;
     private int respawnTask = -1;
+    private int armorTier = 0;
 
     public Context(String arenaId, TeamColor team) {
       this.arenaId = arenaId;
@@ -32,6 +33,9 @@ public final class PlayerContextService {
     public void spectating(boolean s) { this.spectating = s; }
     public int respawnTask() { return respawnTask; }
     public void respawnTask(int id) { this.respawnTask = id; }
+
+    public int armorTier() { return armorTier; }
+    public void armorTier(int tier) { this.armorTier = tier; }
   }
 
   private final Map<UUID, Context> contexts = new ConcurrentHashMap<>();
@@ -97,6 +101,16 @@ public final class PlayerContextService {
 
   public void clearRespawnTask(Player p) {
     setRespawnTask(p, -1);
+  }
+
+  public int getArmorTier(Player p) {
+    Context c = contexts.get(p.getUniqueId());
+    return c == null ? 0 : c.armorTier();
+  }
+
+  public void setArmorTier(Player p, int tier) {
+    Context c = contexts.get(p.getUniqueId());
+    if (c != null) c.armorTier(tier);
   }
 
   public Collection<Player> playersInArena(String arenaId) {

--- a/src/main/java/com/example/bedwars/gui/RulesMenu.java
+++ b/src/main/java/com/example/bedwars/gui/RulesMenu.java
@@ -1,0 +1,17 @@
+package com.example.bedwars.gui;
+
+import com.example.bedwars.BedwarsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+
+/** Simple placeholder rules GUI for players. */
+public final class RulesMenu {
+  private final BedwarsPlugin plugin;
+  public RulesMenu(BedwarsPlugin plugin) { this.plugin = plugin; }
+
+  public void open(Player p) {
+    Inventory inv = Bukkit.createInventory(null, 27, "Règles");
+    p.openInventory(inv);
+  }
+}

--- a/src/main/java/com/example/bedwars/listeners/ArmorLockListener.java
+++ b/src/main/java/com/example/bedwars/listeners/ArmorLockListener.java
@@ -1,0 +1,46 @@
+package com.example.bedwars.listeners;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.game.PlayerContextService;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.PlayerInventory;
+
+/** Prevents removing team armor from legs and feet slots. */
+public final class ArmorLockListener implements Listener {
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService ctx;
+
+  public ArmorLockListener(BedwarsPlugin plugin, PlayerContextService ctx) {
+    this.plugin = plugin; this.ctx = ctx;
+  }
+
+  private boolean enabled() {
+    return plugin.getConfig().getBoolean("armor.lock_legs_feet", true);
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onInvClick(InventoryClickEvent e) {
+    if (!enabled()) return;
+    if (!(e.getWhoClicked() instanceof Player p)) return;
+    if (ctx.getArena(p) == null) return;
+    if (!(e.getClickedInventory() instanceof PlayerInventory)) return;
+    int slot = e.getSlot();
+    if (slot == 36 || slot == 37) {
+      e.setCancelled(true);
+    }
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onDrag(InventoryDragEvent e) {
+    if (!enabled()) return;
+    if (!(e.getWhoClicked() instanceof Player p)) return;
+    if (ctx.getArena(p) == null) return;
+    if (e.getRawSlots().contains(36) || e.getRawSlots().contains(37)) {
+      e.setCancelled(true);
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/listeners/CompassListener.java
+++ b/src/main/java/com/example/bedwars/listeners/CompassListener.java
@@ -1,0 +1,53 @@
+package com.example.bedwars.listeners;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.game.PlayerContextService;
+import com.example.bedwars.gui.RulesMenu;
+import com.example.bedwars.gui.TeamSelectMenu;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+/** Handles compass interactions for rules/team selection menus. */
+public final class CompassListener implements Listener {
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService ctx;
+  private final TeamSelectMenu teamMenu;
+  private final RulesMenu rulesMenu;
+
+  public CompassListener(BedwarsPlugin plugin, PlayerContextService ctx, TeamSelectMenu teamMenu) {
+    this.plugin = plugin; this.ctx = ctx; this.teamMenu = teamMenu; this.rulesMenu = new RulesMenu(plugin);
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onCompassUse(PlayerInteractEvent e) {
+    if (e.getHand() != EquipmentSlot.HAND) return;
+    ItemStack it = e.getItem();
+    if (it == null || !it.hasItemMeta()) return;
+    var pdc = it.getItemMeta().getPersistentDataContainer();
+    String kind = pdc.get(plugin.keys().BW_ITEM(), PersistentDataType.STRING);
+    if (!"compass".equals(kind)) return;
+    Action action = e.getAction();
+    if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) return;
+    Player p = e.getPlayer();
+    if (plugin.getConfig().getBoolean("compass.require_permission", false)
+        && !p.hasPermission("bedwars.menu.rules")) return;
+    String mode = plugin.getConfig().getString("compass.opens", "rules");
+    if ("team_selector".equalsIgnoreCase(mode)) {
+      String arenaId = ctx.getArena(p);
+      if (arenaId != null) {
+        Arena a = plugin.arenas().get(arenaId).orElse(null);
+        if (a != null) teamMenu.open(p, a);
+      }
+    } else {
+      rulesMenu.open(p);
+    }
+    e.setCancelled(true);
+  }
+}

--- a/src/main/java/com/example/bedwars/listeners/EditorListener.java
+++ b/src/main/java/com/example/bedwars/listeners/EditorListener.java
@@ -36,7 +36,7 @@ public final class EditorListener implements Listener {
     if(!(top.getHolder() instanceof BWMenuHolder holder)) return;
     e.setCancelled(true);
     if(!(e.getWhoClicked() instanceof Player p)) return;
-    if(!p.hasPermission("bedwars.admin")) { p.sendMessage(plugin.messages().get("admin.no-perm")); return; }
+    if(!p.hasPermission("bedwars.menu.admin")) { p.sendMessage(plugin.messages().get("admin.no-perm")); return; }
     if(holder.view != AdminView.ARENA_EDITOR || holder.editorView == null) return;
     if(e.getClickedInventory() != top) return;
     int slot = e.getRawSlot();

--- a/src/main/java/com/example/bedwars/listeners/EntityExplodeListener.java
+++ b/src/main/java/com/example/bedwars/listeners/EntityExplodeListener.java
@@ -18,6 +18,7 @@ public final class EntityExplodeListener implements Listener {
   public void onExplode(EntityExplodeEvent e) {
     e.blockList().removeIf(b -> {
       if (Tag.BEDS.isTagged(b.getType())) return true;
+      if (!b.hasMetadata("bw_placed")) return true;
       String arena = buildRules.arenaAt(b.getLocation());
       if (arena == null) return true;
       buildRules.removePlaced(arena, b.getLocation());

--- a/src/main/java/com/example/bedwars/listeners/MenuListener.java
+++ b/src/main/java/com/example/bedwars/listeners/MenuListener.java
@@ -29,7 +29,7 @@ public final class MenuListener implements Listener {
     // Bloquer toute interaction par défaut
     e.setCancelled(true);
     if (!(e.getWhoClicked() instanceof Player p)) return;
-    if (!p.hasPermission("bedwars.admin")) { p.sendMessage(plugin.messages().get("admin.no-perm")); return; }
+    if (!p.hasPermission("bedwars.menu.admin")) { p.sendMessage(plugin.messages().get("admin.no-perm")); return; }
     if (e.getClickedInventory() != top) return; // on ignore l'inventaire bas
     if (e.getCurrentItem() == null) return;
 

--- a/src/main/java/com/example/bedwars/ops/Keys.java
+++ b/src/main/java/com/example/bedwars/ops/Keys.java
@@ -19,6 +19,8 @@ public final class Keys {
   private final NamespacedKey GEN_ID;
   private final NamespacedKey GEN_HOLO;
   private final NamespacedKey GEN_CAP;
+  private final NamespacedKey BW_ITEM;
+  private final NamespacedKey BW_PLACED;
 
   public Keys(Plugin plugin) {
     this.ARENA_ID = new NamespacedKey(plugin, "arena_id");
@@ -29,6 +31,8 @@ public final class Keys {
     this.GEN_ID = new NamespacedKey(plugin, "gen_id");
     this.GEN_HOLO = new NamespacedKey(plugin, "gen_holo");
     this.GEN_CAP = new NamespacedKey(plugin, "gen_cap");
+    this.BW_ITEM = new NamespacedKey(plugin, "bw_item");
+    this.BW_PLACED = new NamespacedKey(plugin, "bw_placed");
   }
 
   public NamespacedKey ARENA_ID() { return ARENA_ID; }
@@ -46,5 +50,9 @@ public final class Keys {
   public NamespacedKey GEN_HOLO() { return GEN_HOLO; }
 
   public NamespacedKey GEN_CAP() { return GEN_CAP; }
+
+  public NamespacedKey BW_ITEM() { return BW_ITEM; }
+
+  public NamespacedKey BW_PLACED() { return BW_PLACED; }
 }
 

--- a/src/main/java/com/example/bedwars/rules/BuildRulesListener.java
+++ b/src/main/java/com/example/bedwars/rules/BuildRulesListener.java
@@ -13,6 +13,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.metadata.FixedMetadataValue;
 
 /**
  * Handles build protections: only allow breaking player placed blocks and
@@ -44,7 +45,10 @@ public final class BuildRulesListener implements Listener {
       p.sendMessage(plugin.messages().get("prefix") + plugin.messages().get("build.not_allowed"));
       return;
     }
+    if (plugin.getConfig().getBoolean("build.require_permission", false)
+        && !p.hasPermission("bedwars.build.place")) { e.setCancelled(true); return; }
     if (!buildRules.isAllowed(e.getBlockPlaced().getType())) { e.setCancelled(true); return; }
+    e.getBlockPlaced().setMetadata("bw_placed", new FixedMetadataValue(plugin, true));
     buildRules.recordPlacement(arenaId, e.getBlockPlaced().getLocation());
   }
 
@@ -57,9 +61,10 @@ public final class BuildRulesListener implements Listener {
     if (a == null || !allowedStates.contains(a.state())) { e.setCancelled(true); return; }
     Block b = e.getBlock();
     if (Tag.BEDS.isTagged(b.getType())) { return; }
-    if (plugin.getConfig().getBoolean("rules.break-only-placed", true) && !buildRules.wasPlaced(arenaId, b.getLocation())) {
+    if (plugin.getConfig().getBoolean("rules.break-only-placed", true) && !b.hasMetadata("bw_placed")) {
       e.setCancelled(true);
     } else {
+      b.removeMetadata("bw_placed", plugin);
       buildRules.removePlaced(arenaId, b.getLocation());
     }
   }

--- a/src/main/java/com/example/bedwars/services/BuildRulesService.java
+++ b/src/main/java/com/example/bedwars/services/BuildRulesService.java
@@ -17,7 +17,9 @@ public final class BuildRulesService {
 
   public BuildRulesService(BedwarsPlugin plugin) {
     this.plugin = plugin;
-    this.allowedPlace = plugin.getConfig().getStringList("rules.place-allow").stream()
+    java.util.List<String> mats = plugin.getConfig().getStringList("build.allowed_materials");
+    if (mats.isEmpty()) mats = plugin.getConfig().getStringList("rules.place-allow");
+    this.allowedPlace = mats.stream()
         .map(Material::matchMaterial)
         .filter(java.util.Objects::nonNull)
         .collect(Collectors.toCollection(HashSet::new));

--- a/src/main/java/com/example/bedwars/shop/ShopListener.java
+++ b/src/main/java/com/example/bedwars/shop/ShopListener.java
@@ -93,6 +93,8 @@ public final class ShopListener implements Listener {
               plugin.upgrades().applySharpness(ih.arenaId, ih.team);
             }
           });
+        } else if (mat.name().endsWith("_BOOTS")) {
+          applyArmorPurchase(p, mat);
         } else {
           p.getInventory().addItem(it);
         }
@@ -167,6 +169,32 @@ public final class ShopListener implements Listener {
           p.sendMessage(plugin.messages().format("upgrades.bought", Map.of("name", def.name)));
           upgradesMenu.open(p, uh.arenaId, uh.team);
         }
+      }
+    }
+  }
+
+  private void applyArmorPurchase(Player p, Material bootsMat) {
+    int tier = switch (bootsMat) {
+      case CHAINMAIL_BOOTS -> 1;
+      case IRON_BOOTS -> 2;
+      case DIAMOND_BOOTS -> 3;
+      default -> 0;
+    };
+    int current = ctx.getArmorTier(p);
+    if (tier <= current) return;
+    ctx.setArmorTier(p, tier);
+    switch (tier) {
+      case 3 -> {
+        p.getInventory().setLeggings(new ItemStack(Material.DIAMOND_LEGGINGS));
+        p.getInventory().setBoots(new ItemStack(Material.DIAMOND_BOOTS));
+      }
+      case 2 -> {
+        p.getInventory().setLeggings(new ItemStack(Material.IRON_LEGGINGS));
+        p.getInventory().setBoots(new ItemStack(Material.IRON_BOOTS));
+      }
+      case 1 -> {
+        p.getInventory().setLeggings(new ItemStack(Material.CHAINMAIL_LEGGINGS));
+        p.getInventory().setBoots(new ItemStack(Material.CHAINMAIL_BOOTS));
       }
     }
   }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -97,6 +97,19 @@ kit:
 
 armor:
   dye_colored: true
+  lock_legs_feet: true
+
+compass:
+  opens: rules   # rules | team_selector
+  require_permission: false
+
+build:
+  allowed_materials: [WHITE_WOOL, GLASS, STAINED_GLASS, END_STONE, OAK_PLANKS, HARDENED_CLAY]
+  require_permission: false
+  bypass_external_protection: true
+
+shop:
+  armor_persistent: true
 
 tnt:
   fuse_ticks: 40

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,3 +15,12 @@ permissions:
   bedwars.admin:
     description: Accès aux commandes admin BedWars
     default: op
+  bedwars.menu.rules:
+    description: Ouvrir le menu Règles via la boussole
+    default: true
+  bedwars.build.place:
+    description: Poser des blocs whitelistes en arène
+    default: true
+  bedwars.menu.admin:
+    description: Accès menus admin BedWars
+    default: op


### PR DESCRIPTION
## Summary
- Allow non-OP players to open the rules or team selector menu via a tagged compass
- Permit whitelisted block placement during games and tag placed blocks to prevent disappearing
- Auto-equip and lock purchased armor pieces with optional persistence across deaths

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce16eb7cc83299e6f401b6fcbe246