### PR TITLE
feat: add scoreboard and action bar

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -61,6 +61,8 @@ public final class BedwarsPlugin extends JavaPlugin {
   private DeathRespawnService deathService;
   private LobbyItemsService lobbyItems;
   private TeamSelectMenu teamSelectMenu;
+  private com.example.bedwars.hud.ScoreboardManager scoreboardManager;
+  private com.example.bedwars.hud.ActionBarBus actionBarBus;
 
   @Override
   public void onEnable() {
@@ -87,6 +89,15 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.buildRules = new BuildRulesService(this);
     this.generatorManager = new GeneratorManager(this);
     this.generatorManager.start();
+
+    this.actionBarBus = new com.example.bedwars.hud.ActionBarBus();
+    if (getConfig().getBoolean("actionbar.enabled", true)) {
+      this.actionBarBus.start(this);
+    }
+    this.scoreboardManager = new com.example.bedwars.hud.ScoreboardManager(this);
+    if (getConfig().getBoolean("scoreboard.enabled", true)) {
+      org.bukkit.Bukkit.getScheduler().runTaskTimer(this, () -> scoreboardManager.tick(), 20L, 20L);
+    }
 
     Objects.requireNonNull(getCommand("bw")).setExecutor(new BwCommand(this));
     Objects.requireNonNull(getCommand("bwadmin")).setExecutor(new BwAdminCommand(this));
@@ -118,6 +129,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   public void onDisable() {
     if (arenaManager != null) arenaManager.saveAll();
     if (generatorManager != null) generatorManager.stop();
+    if (scoreboardManager != null) scoreboardManager.clear();
     getLogger().info("Bedwars disabled.");
   }
 
@@ -151,4 +163,6 @@ public final class BedwarsPlugin extends JavaPlugin {
   public GeneratorManager generators() { return generatorManager; }
   public GameService game() { return gameService; }
   public BuildRulesService buildRules() { return buildRules; }
+  public com.example.bedwars.hud.ScoreboardManager scoreboard() { return scoreboardManager; }
+  public com.example.bedwars.hud.ActionBarBus actionBar() { return actionBarBus; }
 }

--- a/src/main/java/com/example/bedwars/game/GameService.java
+++ b/src/main/java/com/example/bedwars/game/GameService.java
@@ -43,6 +43,11 @@ public final class GameService {
 
   public void setDeathService(DeathRespawnService drs) { this.deathService = drs; }
 
+  /** Returns number of alive players for a team in an arena. */
+  public int aliveCount(String arenaId, TeamColor team) {
+    return contexts.aliveCount(arenaId, team);
+  }
+
   public int diamondTier(String arenaId) {
     return plugin.generators().diamondTier(arenaId);
   }
@@ -121,6 +126,10 @@ public final class GameService {
         if (a.state() != GameState.STARTING) { cancel(); return; }
         if (sec <= 0) { cancel(); beginRunning(a); return; }
         messages.broadcast(a, "game.starting-in", Map.of("sec", sec));
+        String ab = plugin.messages().format("ab.starting_in", Map.of("sec", sec));
+        for (Player p : contexts.playersInArena(a.id())) {
+          plugin.actionBar().push(p, ab, 1);
+        }
         sec--;
       }
     }.runTaskTimer(plugin, 0L, 20L).getTaskId();

--- a/src/main/java/com/example/bedwars/game/PlayerContextService.java
+++ b/src/main/java/com/example/bedwars/game/PlayerContextService.java
@@ -79,6 +79,12 @@ public final class PlayerContextService {
     if (c != null) c.alive(true);
   }
 
+  /** Returns whether the player is marked as alive in their context. */
+  public boolean isAlive(Player p) {
+    Context c = contexts.get(p.getUniqueId());
+    return c != null && c.alive();
+  }
+
   public boolean isSpectating(Player p) {
     Context c = contexts.get(p.getUniqueId());
     return c != null && c.spectating();
@@ -128,6 +134,14 @@ public final class PlayerContextService {
   public int countPlayers(String arenaId, TeamColor team) {
     return (int) Bukkit.getOnlinePlayers().stream()
         .filter(p -> arenaId.equals(getArena(p)) && team == getTeam(p))
+        .count();
+  }
+
+  /** Counts alive players for a given team in an arena. */
+  public int aliveCount(String arenaId, TeamColor team) {
+    return (int) Bukkit.getOnlinePlayers().stream()
+        .filter(p -> arenaId.equals(getArena(p)) && team == getTeam(p))
+        .filter(this::isAlive)
         .count();
   }
 

--- a/src/main/java/com/example/bedwars/gen/GeneratorManager.java
+++ b/src/main/java/com/example/bedwars/gen/GeneratorManager.java
@@ -71,6 +71,26 @@ public final class GeneratorManager {
     return Math.max(0, g.cooldown / 20);
   }
 
+  /** Returns seconds until next diamond generator drop in arena. */
+  public int nextDiamondDropSeconds(String arenaId) {
+    Map<UUID, RuntimeGen> m = runtime.get(arenaId);
+    if (m == null) return 0;
+    return m.values().stream()
+        .filter(g -> g.type == GeneratorType.DIAMOND)
+        .mapToInt(g -> Math.max(0, g.cooldown / 20))
+        .min().orElse(0);
+  }
+
+  /** Returns seconds until next emerald generator drop in arena. */
+  public int nextEmeraldDropSeconds(String arenaId) {
+    Map<UUID, RuntimeGen> m = runtime.get(arenaId);
+    if (m == null) return 0;
+    return m.values().stream()
+        .filter(g -> g.type == GeneratorType.EMERALD)
+        .mapToInt(g -> Math.max(0, g.cooldown / 20))
+        .min().orElse(0);
+  }
+
   // Called at STARTING->RUNNING and on arena reload
   public void refreshArena(String arenaId) {
     plugin.arenas().get(arenaId).ifPresent(arena -> {

--- a/src/main/java/com/example/bedwars/hud/ActionBarBus.java
+++ b/src/main/java/com/example/bedwars/hud/ActionBarBus.java
@@ -1,0 +1,46 @@
+package com.example.bedwars.hud;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Simple bus to send transient action bar messages with TTL.
+ */
+public final class ActionBarBus {
+  private static final class Msg {
+    final BaseComponent[] comp;
+    int ttl;
+    Msg(BaseComponent[] c, int t) { comp = c; ttl = t; }
+  }
+
+  private final Map<UUID, Msg> current = new HashMap<>();
+
+  /** Push a new message for a player lasting a number of seconds. */
+  public void push(Player p, String legacyColorMsg, int seconds) {
+    current.put(p.getUniqueId(), new Msg(
+        TextComponent.fromLegacyText(org.bukkit.ChatColor.translateAlternateColorCodes('&', legacyColorMsg)),
+        seconds));
+  }
+
+  /** Starts the repeating task to dispatch messages each second. */
+  public void start(Plugin plugin) {
+    Bukkit.getScheduler().runTaskTimer(plugin, () -> {
+      Iterator<Map.Entry<UUID, Msg>> it = current.entrySet().iterator();
+      while (it.hasNext()) {
+        var e = it.next();
+        Player p = Bukkit.getPlayer(e.getKey());
+        if (p == null) { it.remove(); continue; }
+        p.spigot().sendMessage(ChatMessageType.ACTION_BAR, e.getValue().comp);
+        if (--e.getValue().ttl <= 0) it.remove();
+      }
+    }, 0L, 20L);
+  }
+}

--- a/src/main/java/com/example/bedwars/hud/ScoreboardManager.java
+++ b/src/main/java/com/example/bedwars/hud/ScoreboardManager.java
@@ -1,0 +1,139 @@
+package com.example.bedwars.hud;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.GameState;
+import com.example.bedwars.arena.TeamColor;
+import com.example.bedwars.game.PlayerContextService;
+import java.util.*;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.Team;
+
+/**
+ * Renders the sidebar scoreboard for BedWars games without flicker.
+ */
+public final class ScoreboardManager {
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService players;
+  private final Map<UUID, PlayerBoard> boards = new HashMap<>();
+  private static final String[] KEYS = {
+      "\u00a71","\u00a72","\u00a73","\u00a74","\u00a75","\u00a76","\u00a77","\u00a78",
+      "\u00a79","\u00a7a","\u00a7b","\u00a7c","\u00a7d","\u00a7e","\u00a7f"};
+
+  public ScoreboardManager(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+    this.players = plugin.contexts();
+  }
+
+  private String msg(String key) { return plugin.messages().get(key); }
+
+  /** Attach scoreboard to player if not already. */
+  public void attach(Player p) {
+    if (boards.containsKey(p.getUniqueId())) return;
+    Scoreboard sb = Bukkit.getScoreboardManager().getNewScoreboard();
+    Objective o = sb.registerNewObjective("bw", org.bukkit.scoreboard.Criteria.DUMMY, color(msg("sb.title")));
+    o.setDisplaySlot(DisplaySlot.SIDEBAR);
+    for (int i = 0; i < KEYS.length; i++) {
+      Team t = sb.registerNewTeam("L" + i);
+      t.addEntry(KEYS[i]);
+      o.getScore(KEYS[i]).setScore(15 - i);
+    }
+    p.setScoreboard(sb);
+    boards.put(p.getUniqueId(), new PlayerBoard(p, sb));
+  }
+
+  /** Detach scoreboard from all players. */
+  public void clear() {
+    boards.keySet().forEach(id -> {
+      Player p = Bukkit.getPlayer(id);
+      if (p != null) p.setScoreboard(Bukkit.getScoreboardManager().getNewScoreboard());
+    });
+    boards.clear();
+  }
+
+  /** Tick rendering for all arenas and players. */
+  public void tick() {
+    Set<UUID> seen = new HashSet<>();
+    FileConfiguration config = plugin.getConfig();
+    for (Arena a : plugin.arenas().all()) {
+      if (a.state() != GameState.STARTING && a.state() != GameState.RUNNING) continue;
+      for (Player p : players.playersInArena(a.id())) {
+        attach(p);
+        renderFor(p, a, config);
+        seen.add(p.getUniqueId());
+      }
+    }
+    Iterator<Map.Entry<UUID, PlayerBoard>> it = boards.entrySet().iterator();
+    while (it.hasNext()) {
+      var e = it.next();
+      if (!seen.contains(e.getKey())) {
+        Player p = Bukkit.getPlayer(e.getKey());
+        if (p != null) p.setScoreboard(Bukkit.getScoreboardManager().getNewScoreboard());
+        it.remove();
+      }
+    }
+  }
+
+  private void renderFor(Player p, Arena a, FileConfiguration config) {
+    Scoreboard sb = boards.get(p.getUniqueId()).board();
+    int i = 0;
+    set(sb, i++, color("&7Carte: &f" + a.id()));
+    set(sb, i++, " ");
+    for (TeamColor tc : a.activeTeams()) {
+      boolean bed = a.team(tc).bedBlock() != null;
+      String sym = bed ? msg("sb.bed_ok") : msg("sb.bed_broken");
+      int alive = players.aliveCount(a.id(), tc);
+      String line = tc.color + tc.display + " &7" + sym + " &f(" + alive + ")";
+      set(sb, i++, color(line));
+      if (i >= 10) break;
+    }
+    set(sb, i++, "  ");
+    int dTier = plugin.generators().diamondTier(a.id());
+    int dSec = plugin.generators().nextDiamondDropSeconds(a.id());
+    int eTier = plugin.generators().emeraldTier(a.id());
+    int eSec = plugin.generators().nextEmeraldDropSeconds(a.id());
+    set(sb, i++, color(msg("sb.diamond_line").replace("{tier}", roman(dTier)).replace("{sec}", String.valueOf(dSec))));
+    set(sb, i++, color(msg("sb.emerald_line").replace("{tier}", roman(eTier)).replace("{sec}", String.valueOf(eSec))));
+    set(sb, i++, "   ");
+    set(sb, i++, color("&7" + config.getString("scoreboard.brand_line", "play: exemple.fr")));
+    while (i < KEYS.length) set(sb, i++, "");
+  }
+
+  private void set(Scoreboard sb, int line, String text) {
+    Team t = sb.getTeam("L" + line);
+    if (t != null) setSplit(t, text);
+  }
+
+  private void setSplit(Team team, String text) {
+    String[] parts = split16(text);
+    team.setPrefix(parts[0]);
+    team.setSuffix(parts[1]);
+  }
+
+  private static String[] split16(String s) {
+    if (s == null) s = "";
+    if (s.length() <= 16) return new String[] {s, ""};
+    return new String[] {s.substring(0, 16), s.substring(16, Math.min(32, s.length()))};
+  }
+
+  private static String color(String s) {
+    return ChatColor.translateAlternateColorCodes('&', s);
+  }
+
+  private static String roman(int n) {
+    return switch (n) {
+      case 1 -> "I";
+      case 2 -> "II";
+      case 3 -> "III";
+      default -> "-";
+    };
+  }
+
+  private record PlayerBoard(Player p, Scoreboard board) {}
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -122,3 +122,9 @@ lobby:
   leave_item:
     material: BARRIER
     name: "&cQuitter l'arène"
+
+scoreboard:
+  enabled: true
+  brand_line: "play: exemple.fr"
+actionbar:
+  enabled: true

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -137,3 +137,14 @@ eliminated_title: "&cÉliminé"
 eliminated_sub: "&7Votre lit est détruit"
 build:
   not_allowed: "&cVous ne pouvez pas construire ici."
+sb:
+  title: "&e&lBEDWARS"
+  bed_ok: "✔"
+  bed_broken: "✖"
+  diamond_line: "&bDiamant: &fTier {tier} &7t-{sec}s"
+  emerald_line: "&aÉmeraude: &fTier {tier} &7t-{sec}s"
+ab:
+  starting_in: "&eDépart dans &6{sec}s"
+  trap_triggered: "&cPiège déclenché !"
+  bed_broken: "&eLit de &f{team}&e détruit !"
+  tier_up: "&b{res} Tier {tier} atteint"


### PR DESCRIPTION
## Summary
- add scoreboard manager with per-second sidebar refresh
- add action bar bus for transient alerts
- wire managers into plugin and configuration

## Testing
- `mvn -q test` *(fails: The following artifacts could not be resolved... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce89ec0dc83298c7cb85e6168082c