### PR TITLE
feat: add flexible messaging API

### DIFF
--- a/src/main/java/com/example/bedwars/util/Args.java
+++ b/src/main/java/com/example/bedwars/util/Args.java
@@ -1,0 +1,20 @@
+package com.example.bedwars.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Utility for building placeholder maps without repeated Map.of calls. */
+public final class Args {
+  private Args() {}
+
+  public static Map<String, Object> of(Object... kv) {
+    if (kv.length % 2 != 0) {
+      throw new IllegalArgumentException("pairs required");
+    }
+    Map<String, Object> m = new LinkedHashMap<>();
+    for (int i = 0; i < kv.length; i += 2) {
+      m.put(String.valueOf(kv[i]), kv[i + 1]);
+    }
+    return m;
+  }
+}

--- a/src/main/java/com/example/bedwars/util/Messages.java
+++ b/src/main/java/com/example/bedwars/util/Messages.java
@@ -1,5 +1,7 @@
 package com.example.bedwars.util;
 
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
@@ -7,12 +9,15 @@ import java.util.stream.Collectors;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.entity.Player;
 
+/** Utility for retrieving, formatting and sending plugin messages. */
 public final class Messages {
+  private final BedwarsPlugin plugin;
   private final FileConfiguration cfg;
 
-  public Messages(JavaPlugin plugin) {
+  public Messages(BedwarsPlugin plugin) {
+    this.plugin = plugin;
     File f = new File(plugin.getDataFolder(), "messages.yml");
     if (!f.exists()) {
       plugin.saveResource("messages.yml", false);
@@ -20,17 +25,49 @@ public final class Messages {
     this.cfg = YamlConfiguration.loadConfiguration(f);
   }
 
+  /**
+   * Retrieves a message by key and translates color codes.
+   * If the key is missing, the key itself is returned.
+   */
   public String get(String path) {
     String raw = cfg.getString(path, path);
     return ChatColor.translateAlternateColorCodes('&', raw);
   }
 
+  /** Formats a message with the given placeholders and color codes. */
   public String format(String path, Map<String, ?> placeholders) {
-    String msg = get(path);
-    for (Map.Entry<String, ?> e : placeholders.entrySet()) {
-      msg = msg.replace("{" + e.getKey() + "}", String.valueOf(e.getValue()));
+    String msg = cfg.getString(path, path);
+    if (placeholders != null) {
+      for (Map.Entry<String, ?> e : placeholders.entrySet()) {
+        msg = msg.replace("{" + e.getKey() + "}", String.valueOf(e.getValue()));
+      }
     }
-    return msg;
+    return ChatColor.translateAlternateColorCodes('&', msg);
+  }
+
+  /** Sends a formatted message to a player without placeholders. */
+  public void send(Player p, String key) {
+    send(p, key, Map.of());
+  }
+
+  /** Sends a formatted message with placeholders to a player. */
+  public void send(Player p, String key, Map<String, ?> tokens) {
+    p.sendMessage(format(key, tokens));
+  }
+
+  /** Broadcasts a message to all players in an arena without placeholders. */
+  public void broadcast(Arena a, String key) {
+    for (Player p : plugin.contexts().playersInArena(a.id())) {
+      send(p, key);
+    }
+  }
+
+  /** Broadcasts a formatted message with placeholders to an arena. */
+  public void broadcast(Arena a, String key, Map<String, ?> tokens) {
+    String msg = format(key, tokens);
+    for (Player p : plugin.contexts().playersInArena(a.id())) {
+      p.sendMessage(msg);
+    }
   }
 
   public List<String> getList(String path) {

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -104,6 +104,8 @@ game:
   bed-own: "&cC'est votre lit !"
   eliminated: "&c{player} a été éliminé."
   victory: "&6Victoire de l'équipe {team} !"
+  win: "&6Victoire de l'équipe {team} !"
+  bed_broken: "&cLe lit de {team} &ca été détruit !"
   respawn-in: "&eRespawn dans &6{sec}s"
   respawn-now: "&aVous réapparaissez !"
   spectating: "&7Vous êtes spectateur."
@@ -157,3 +159,6 @@ reset:
   preparing: "&7Préparation du reset..."
   done: "&aReset terminé. Retour en &fWAITING"
   failed: "&cÉchec du reset: &f{error}"
+forcestart:
+  countdown: "&eLa partie démarre dans &6{sec}s"
+  started: "&aLa partie commence !"


### PR DESCRIPTION
## Summary
- expand Messages utility with send/broadcast helpers using Map<String, ?> tokens
- add Args helper for building placeholder maps
- extend default messages with forcestart and win/broken bed entries

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ceec9cbc08329bfc1b52a073f9e3b