### PR TITLE
Finalize French UX, permissions, and admin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,41 @@
-# Bedwars
+# Guide Admin BedWars
 
-Squelette minimal d'un plugin BedWars pour Spigot/Paper 1.21.
+Plugin BedWars pour Spigot/Paper 1.21.
 
-## Compilation
+## Installation
+1. Compiler le plugin : `mvn package`.
+2. Déposer `target/bedwars-0.0.1.jar` dans `plugins/`.
+3. Démarrer le serveur pour générer la structure :
+   - `plugins/Bedwars/arenas/`
+   - `plugins/Bedwars/templates/`
+   - fichiers `config.yml`, `messages.yml`, `shop.yml`, `upgrades.yml`, `rotation.yml`.
 
-```bash
-mvn -DskipTests package
-```
+## Setup rapide
+1. `/bw menu` → menu admin.
+2. Créer une arène → définir Lobby, Spawns/Lits pour chaque équipe.
+3. Ajouter PNJ boutique & upgrades, générateurs.
+4. `Save` puis `/bwadmin game start <id>` pour tester.
 
-Le JAR généré se trouve dans `target/bedwars-0.0.1.jar` et doit être
-placé dans le dossier `plugins/` d'un serveur Paper/Spigot 1.21.
+## Commandes & permissions
+| Commande | Permission |
+|---------|------------|
+| `/bw help` | *(aucune)* |
+| `/bw join <arène>` | *(aucune)* |
+| `/bw menu` | `bedwars.admin.arena` |
+| `/bwadmin arena <...>` | `bedwars.admin.arena` |
+| `/bwadmin game <...>` | `bedwars.admin.game` |
+| `/bwadmin debug status <arène>` | `bedwars.admin.debug` |
+| `/bwadmin maintenance cleanup <arène>` | `bedwars.admin.maintenance` |
 
-## Éditeur d'arène (Étape 4)
+Permissions globales : `bedwars.admin.*` (ops par défaut) et gameplay :
+`bedwars.menu.rules`, `bedwars.build.place`.
 
-Un assistant permet de créer une arène via le menu admin (laine verte).
-Après saisie de l'identifiant, l'éditeur s'ouvre avec les actions
-suivantes (slots principaux) :
+## Captures
+Captures d'écran à insérer ici.
 
-| Slot | Action |
-|-----:|--------|
-| 10 | Définir le lobby |
-| 12 | Ouvrir la gestion des équipes |
-| 14 | Ajouter des PNJ |
-| 16 | Ajouter des générateurs |
-| 28 | Sauvegarder |
-| 30 | Recharger |
-| 32 | Supprimer |
-| 49 | Retour |
+## FAQ
+- **Je ne peux pas placer de blocs en arène** : vérifier `bedwars.build.place`.
+- **Le TNT ne s'allume pas** : assurez-vous que l'arène n'est pas en mode `WAITING`.
+- **Le scoreboard n'apparaît pas** : vérifier `scoreboard.enabled` dans `config.yml`.
+- **Permissions** : utiliser `bedwars.admin.*` ou les sous-permissions détaillées ci-dessus.
 
-Les sous-menus permettent d'activer une équipe, de positionner ses spawns
-et lits, de poser les PNJ boutique/upgrade et d'ajouter les générateurs
-marqués.

--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -151,6 +151,13 @@ public final class BedwarsPlugin extends JavaPlugin {
     return messages;
   }
 
+  public String msg(String key){ return messages.msg(key); }
+  public String msg(String key, java.util.Map<String, ?> tokens){ return messages.msg(key, tokens); }
+
+  public void logInfo(String fmt, Object... args){ getLogger().info(String.format(fmt, args)); }
+  public void logWarning(String fmt, Object... args){ getLogger().warning(String.format(fmt, args)); }
+  public void logSevere(String fmt, Object... args){ getLogger().severe(String.format(fmt, args)); }
+
   public ArenaManager arenas() {
     return arenaManager;
   }

--- a/src/main/java/com/example/bedwars/command/BwAdminCommand.java
+++ b/src/main/java/com/example/bedwars/command/BwAdminCommand.java
@@ -28,8 +28,8 @@ public final class BwAdminCommand implements CommandExecutor {
 
   @Override
   public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
-    if (!sender.hasPermission("bedwars.admin")) {
-      sender.sendMessage(plugin.messages().get("errors.no-perm"));
+    if (!sender.hasPermission("bedwars.admin.*")) {
+      sender.sendMessage(plugin.messages().get("errors.no_perm"));
       return true;
     }
     if (args.length == 0 || args[0].equalsIgnoreCase("help")) {
@@ -39,11 +39,19 @@ public final class BwAdminCommand implements CommandExecutor {
     }
 
     if (args[0].equalsIgnoreCase("arena")) {
+      if (!sender.hasPermission("bedwars.admin.arena")) {
+        sender.sendMessage(plugin.messages().get("errors.no_perm"));
+        return true;
+      }
       handleArena(sender, args);
       return true;
     }
 
     if (args[0].equalsIgnoreCase("game")) {
+      if (!sender.hasPermission("bedwars.admin.game")) {
+        sender.sendMessage(plugin.messages().get("errors.no_perm"));
+        return true;
+      }
       handleGame(sender, args);
       return true;
     }
@@ -162,7 +170,7 @@ public final class BwAdminCommand implements CommandExecutor {
 
   private void handleDebug(CommandSender sender, String[] args) {
     if (!sender.hasPermission("bedwars.admin.debug")) {
-      sender.sendMessage(plugin.messages().get("admin.no_perm"));
+      sender.sendMessage(plugin.messages().get("errors.no_perm"));
       return;
     }
     if (args.length < 3 || !args[1].equalsIgnoreCase("status")) {
@@ -174,7 +182,7 @@ public final class BwAdminCommand implements CommandExecutor {
 
   private void handleMaintenance(CommandSender sender, String[] args) {
     if (!sender.hasPermission("bedwars.admin.maintenance")) {
-      sender.sendMessage(plugin.messages().get("admin.no_perm"));
+      sender.sendMessage(plugin.messages().get("errors.no_perm"));
       return;
     }
     if (args.length < 3 || !args[1].equalsIgnoreCase("cleanup")) {
@@ -191,7 +199,7 @@ public final class BwAdminCommand implements CommandExecutor {
   private boolean onDebugStatus(CommandSender s, String id) {
     var opt = plugin.arenas().get(id);
     if (opt.isEmpty()) {
-      msg(s, "admin.arena_unknown", Map.of("arena", id));
+      msg(s, "errors.arena_unknown", Map.of("arena", id));
       return true;
     }
     Arena a = opt.get();
@@ -216,7 +224,7 @@ public final class BwAdminCommand implements CommandExecutor {
   private boolean onMaintenanceCleanup(CommandSender s, String id) {
     var opt = plugin.arenas().get(id);
     if (opt.isEmpty()) {
-      msg(s, "admin.arena_unknown", Map.of("arena", id));
+      msg(s, "errors.arena_unknown", Map.of("arena", id));
       return true;
     }
     msg(s, "maintenance.start", Map.of("arena", id));

--- a/src/main/java/com/example/bedwars/command/BwCommand.java
+++ b/src/main/java/com/example/bedwars/command/BwCommand.java
@@ -48,8 +48,8 @@ public final class BwCommand implements CommandExecutor {
           }
           return true;
         case "menu":
-          if (!player.hasPermission("bedwars.admin")) {
-            player.sendMessage(plugin.messages().get("admin.no-perm"));
+          if (!player.hasPermission("bedwars.admin.arena")) {
+            player.sendMessage(plugin.messages().get("errors.no_perm"));
             return true;
           }
           plugin.menus().open(AdminView.ROOT, player, null);

--- a/src/main/java/com/example/bedwars/gui/TeamSelectMenu.java
+++ b/src/main/java/com/example/bedwars/gui/TeamSelectMenu.java
@@ -68,7 +68,7 @@ public final class TeamSelectMenu implements Listener {
       if (clicked.getType() == tc.wool) {
         int count = ctx.countPlayers(arenaId, tc);
         if (count >= a.maxTeamSize()) {
-          p.sendMessage(plugin.messages().format("team.full", java.util.Map.of("count", count, "max", a.maxTeamSize())));
+          p.sendMessage(plugin.messages().format("errors.team_full", java.util.Map.of("count", count, "max", a.maxTeamSize())));
           return;
         }
         ctx.setTeam(p, tc);

--- a/src/main/java/com/example/bedwars/hud/ScoreboardManager.java
+++ b/src/main/java/com/example/bedwars/hud/ScoreboardManager.java
@@ -8,7 +8,6 @@ import com.example.bedwars.game.PlayerContextService;
 import java.util.*;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Objective;
@@ -37,7 +36,7 @@ public final class ScoreboardManager {
   public void attach(Player p) {
     if (boards.containsKey(p.getUniqueId())) return;
     Scoreboard sb = Bukkit.getScoreboardManager().getNewScoreboard();
-    Objective o = sb.registerNewObjective("bw", org.bukkit.scoreboard.Criteria.DUMMY, color(msg("sb.title")));
+    Objective o = sb.registerNewObjective("bw", org.bukkit.scoreboard.Criteria.DUMMY, color(msg("scoreboard.title")));
     o.setDisplaySlot(DisplaySlot.SIDEBAR);
     for (int i = 0; i < KEYS.length; i++) {
       Team t = sb.registerNewTeam("L" + i);
@@ -60,12 +59,11 @@ public final class ScoreboardManager {
   /** Tick rendering for all arenas and players. */
   public void tick() {
     Set<UUID> seen = new HashSet<>();
-    FileConfiguration config = plugin.getConfig();
     for (Arena a : plugin.arenas().all()) {
       if (a.state() != GameState.STARTING && a.state() != GameState.RUNNING) continue;
       for (Player p : players.playersInArena(a.id())) {
         attach(p);
-        renderFor(p, a, config);
+        renderFor(p, a);
         seen.add(p.getUniqueId());
       }
     }
@@ -80,14 +78,14 @@ public final class ScoreboardManager {
     }
   }
 
-  private void renderFor(Player p, Arena a, FileConfiguration config) {
+  private void renderFor(Player p, Arena a) {
     Scoreboard sb = boards.get(p.getUniqueId()).board();
     int i = 0;
     set(sb, i++, color("&7Carte: &f" + a.id()));
     set(sb, i++, " ");
     for (TeamColor tc : a.activeTeams()) {
       boolean bed = a.team(tc).bedBlock() != null;
-      String sym = bed ? msg("sb.bed_ok") : msg("sb.bed_broken");
+      String sym = bed ? msg("scoreboard.bed_ok") : msg("scoreboard.bed_broken");
       int alive = players.aliveCount(a.id(), tc);
       String line = tc.color + tc.display + " &7" + sym + " &f(" + alive + ")";
       set(sb, i++, color(line));
@@ -98,10 +96,10 @@ public final class ScoreboardManager {
     int dSec = plugin.generators().nextDiamondDropSeconds(a.id());
     int eTier = plugin.generators().emeraldTier(a.id());
     int eSec = plugin.generators().nextEmeraldDropSeconds(a.id());
-    set(sb, i++, color(msg("sb.diamond_line").replace("{tier}", roman(dTier)).replace("{sec}", String.valueOf(dSec))));
-    set(sb, i++, color(msg("sb.emerald_line").replace("{tier}", roman(eTier)).replace("{sec}", String.valueOf(eSec))));
+    set(sb, i++, color(msg("scoreboard.diamond_line").replace("{tier}", roman(dTier)).replace("{sec}", String.valueOf(dSec))));
+    set(sb, i++, color(msg("scoreboard.emerald_line").replace("{tier}", roman(eTier)).replace("{sec}", String.valueOf(eSec))));
     set(sb, i++, "   ");
-    set(sb, i++, color("&7" + config.getString("scoreboard.brand_line", "play: exemple.fr")));
+    set(sb, i++, color("&7" + plugin.messages().get("brand.line")));
     while (i < KEYS.length) set(sb, i++, "");
   }
 

--- a/src/main/java/com/example/bedwars/listeners/EditorListener.java
+++ b/src/main/java/com/example/bedwars/listeners/EditorListener.java
@@ -36,7 +36,7 @@ public final class EditorListener implements Listener {
     if(!(top.getHolder() instanceof BWMenuHolder holder)) return;
     e.setCancelled(true);
     if(!(e.getWhoClicked() instanceof Player p)) return;
-    if(!p.hasPermission("bedwars.menu.admin")) { p.sendMessage(plugin.messages().get("admin.no-perm")); return; }
+    if(!p.hasPermission("bedwars.admin.arena")) { p.sendMessage(plugin.messages().get("errors.no_perm")); return; }
     if(holder.view != AdminView.ARENA_EDITOR || holder.editorView == null) return;
     if(e.getClickedInventory() != top) return;
     int slot = e.getRawSlot();

--- a/src/main/java/com/example/bedwars/listeners/MenuListener.java
+++ b/src/main/java/com/example/bedwars/listeners/MenuListener.java
@@ -29,7 +29,7 @@ public final class MenuListener implements Listener {
     // Bloquer toute interaction par défaut
     e.setCancelled(true);
     if (!(e.getWhoClicked() instanceof Player p)) return;
-    if (!p.hasPermission("bedwars.menu.admin")) { p.sendMessage(plugin.messages().get("admin.no-perm")); return; }
+    if (!p.hasPermission("bedwars.admin.arena")) { p.sendMessage(plugin.messages().get("errors.no_perm")); return; }
     if (e.getClickedInventory() != top) return; // on ignore l'inventaire bas
     if (e.getCurrentItem() == null) return;
 

--- a/src/main/java/com/example/bedwars/util/Io.java
+++ b/src/main/java/com/example/bedwars/util/Io.java
@@ -1,0 +1,17 @@
+package com.example.bedwars.util;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+
+public final class Io {
+  private static final ExecutorService POOL = Executors.newFixedThreadPool(
+      Math.max(2, Runtime.getRuntime().availableProcessors() / 2));
+
+  private Io() {}
+
+  public static <T> CompletableFuture<T> async(Supplier<T> task) {
+    return CompletableFuture.supplyAsync(task, POOL);
+  }
+}

--- a/src/main/java/com/example/bedwars/util/Messages.java
+++ b/src/main/java/com/example/bedwars/util/Messages.java
@@ -34,6 +34,14 @@ public final class Messages {
     return ChatColor.translateAlternateColorCodes('&', raw);
   }
 
+  public String msg(String key) {
+    return get(key);
+  }
+
+  public String msg(String key, Map<String, ?> tokens) {
+    return format(key, tokens);
+  }
+
   /** Formats a message with the given placeholders and color codes. */
   public String format(String path, Map<String, ?> placeholders) {
     String msg = cfg.getString(path, path);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -126,7 +126,6 @@ lobby:
 
 scoreboard:
   enabled: true
-  brand_line: "play: exemple.fr"
 actionbar:
   enabled: true
 

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,5 +1,35 @@
 prefix: "&6[BedWars]&r "
 
+errors:
+  no_perm: "&cTu n'as pas la permission."
+  arena_unknown: "&cArène inconnue: &f{arena}"
+  team_full: "&cCette équipe est pleine (&f{count}/{max}&c)."
+
+menu:
+  title_admin: "&eMenu Admin"
+  team_mode_title: "&eMode d'équipes"
+  running_locked: "&cAction impossible pendant une partie."
+
+player:
+  joined_arena: "&aTu as rejoint &f{arena}&a."
+  left_arena: "&eTu as quitté &f{arena}&e."
+
+scoreboard:
+  title: "&e&lBEDWARS"
+  bed_ok: "✔"
+  bed_broken: "✖"
+  diamond_line: "&bDiamant: &fTier {tier} &7t-{sec}s"
+  emerald_line: "&aÉmeraude: &fTier {tier} &7t-{sec}s"
+
+actionbar:
+  starting_in: "&eDépart dans &6{sec}s"
+  trap_triggered: "&cPiège déclenché !"
+  bed_broken: "&eLit de &f{team}&e détruit !"
+  tier_up: "&b{res} Tier {tier} atteint"
+
+brand:
+  line: "play: exemple.fr"
+
 help.player:
   - "&eCommandes joueur:"
   - "&7/bw help &f- aide"
@@ -15,7 +45,6 @@ help.admin:
   - "&7/bwadmin arena reload <id> &f- recharge une arene"
   - "&7/bwadmin arena delete <id> &f- supprime une arene"
 
-errors.no-perm: "&cVous n'avez pas la permission."
 generic.reloaded: "&aConfiguration rechargée."
 arena.created: "&aArène %s créée."
 arena.deleted: "&aArène %s supprimée."
@@ -28,7 +57,6 @@ arena.world-required: "&cMonde requis."
 
 admin:
   menu-title: "&8Gestion BedWars"
-  no-perm: "&cVous n'avez pas la permission &7(bedwars.admin)."
 
   root:
     arenas: "&eArènes"
@@ -49,9 +77,6 @@ admin:
     diagnostics-lore: "&7État, compteurs, cleanup"
     info: "&fRetour / Infos"
     info-lore: "&7Aide & raccourcis commandes"
-  arena_unknown: "&cArène inconnue: &f{arena}"
-  no_perm: "&cTu n'as pas la permission."
-
   placeholders:
     wip: "&7Cette vue sera complétée à l'étape suivante."
 
@@ -92,9 +117,7 @@ shop:
   trap-added: "&aPiège ajouté. File: {count}/3"
 
 game:
-  join: "&aVous avez rejoint &e{arena}&a."
   already-in: "&7Vous êtes déjà dans une arène."
-  left: "&eVous avez quitté l'arène."
   starting-in: "&aLa partie démarre dans &e{sec}s&a…"
   started: "&aLa partie commence !"
   not-enough: "&cJoueurs insuffisants (&e{count}/{min}&c)."
@@ -141,18 +164,6 @@ eliminated_title: "&cÉliminé"
 eliminated_sub: "&7Votre lit est détruit"
 build:
   not_allowed: "&cVous ne pouvez pas construire ici."
-sb:
-  title: "&e&lBEDWARS"
-  bed_ok: "✔"
-  bed_broken: "✖"
-  diamond_line: "&bDiamant: &fTier {tier} &7t-{sec}s"
-  emerald_line: "&aÉmeraude: &fTier {tier} &7t-{sec}s"
-ab:
-  starting_in: "&eDépart dans &6{sec}s"
-  trap_triggered: "&cPiège déclenché !"
-  bed_broken: "&eLit de &f{team}&e détruit !"
-  tier_up: "&b{res} Tier {tier} atteint"
-
 rotation:
   picking: "&7Sélection de la prochaine arène..."
   picked: "&aArène suivante: &f{arena}"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,21 +12,23 @@ commands:
     description: Commandes admin BedWars
     usage: /bwadmin <arena|game|menu>
 permissions:
-  bedwars.admin:
-    description: Accès aux commandes admin BedWars
+  bedwars.admin.*:
+    description: Tous les droits BedWars
     default: op
-  bedwars.admin.debug:
-    description: Debug d'une arène (status)
-    default: op
-  bedwars.admin.maintenance:
-    description: Maintenance (cleanup entités taguées)
-    default: op
+    children:
+      bedwars.admin.arena: true
+      bedwars.admin.team: true
+      bedwars.admin.npc: true
+      bedwars.admin.gen: true
+      bedwars.admin.rules: true
+      bedwars.admin.game: true
+      bedwars.admin.rotation: true
+      bedwars.admin.reset: true
+      bedwars.admin.debug: true
+      bedwars.admin.maintenance: true
   bedwars.menu.rules:
     description: Ouvrir le menu Règles via la boussole
     default: true
   bedwars.build.place:
     description: Poser des blocs whitelistes en arène
     default: true
-  bedwars.menu.admin:
-    description: Accès menus admin BedWars
-    default: op


### PR DESCRIPTION
## Summary
- Provide fully localized French `messages.yml` with structured error, actionbar and scoreboard keys
- Introduce centralized admin permission tree and logging helpers
- Add async reset executor, brand line support and detailed admin README (screenshots to be added)
- Remove placeholder screenshot binaries from repository

## Testing
- `mvn -q package` *(fails: PluginResolutionException – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cf38d489483298ea84e8e6af3ba60