### PR TITLE
fix: allow block placement and bed destruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ Captures d'écran à insérer ici.
 - **Le TNT ne s'allume pas** : assurez-vous que l'arène n'est pas en mode `WAITING`.
 - **Le scoreboard n'apparaît pas** : vérifier `scoreboard.enabled` dans `config.yml`.
 - **Permissions** : utiliser `bedwars.admin.*` ou les sous-permissions détaillées ci-dessus.
+- **Les blocs disparaissent immédiatement** : mettre `spawn-protection=0` dans `server.properties` ou placer les arènes hors du rayon de spawn. Pour WorldGuard, créer une région autorisant build pendant la partie ou activer `build.worldguard_bypass`.
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -108,6 +108,7 @@ build:
   allowed_materials: [WHITE_WOOL, GLASS, STAINED_GLASS, END_STONE, OAK_PLANKS, HARDENED_CLAY]
   require_permission: false
   bypass_external_protection: true
+  worldguard_bypass: false
 
 shop:
   armor_persistent: true

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -4,6 +4,11 @@ errors:
   no_perm: "&cTu n'as pas la permission."
   arena_unknown: "&cArène inconnue: &f{arena}"
   team_full: "&cCette équipe est pleine (&f{count}/{max}&c)."
+  not_running: "&cAction impossible hors partie."
+  not_allowed_block: "&cBloc non autorisé."
+  map_protected: "&cCarte protégée."
+  own_bed: "&cTu ne peux pas casser ton propre lit !"
+  bed_already_broken: "&eCe lit est déjà détruit."
 
 menu:
   title_admin: "&eMenu Admin"


### PR DESCRIPTION
## Summary
- ensure whitelist block placement only during running games and tag blocks
- protect original map blocks while allowing enemy bed destruction
- document spawn protection and worldguard requirements

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d0435af3c832990537a05d4b9edb2