### PR TITLE
Fix build and bed protection logic

### DIFF
--- a/src/main/java/com/example/bedwars/arena/TeamData.java
+++ b/src/main/java/com/example/bedwars/arena/TeamData.java
@@ -10,7 +10,7 @@ import com.example.bedwars.shop.TeamUpgradesState;
  */
 public final class TeamData {
   private Location spawn;        // null until defined
-  private Location bedBlock;     // "head" block of the bed
+  private Location bedBlock;     // "foot" block of the bed
   private int maxPlayers = 4;
   private final TeamUpgradesState upgrades = new TeamUpgradesState();
 

--- a/src/main/java/com/example/bedwars/listeners/EditorListener.java
+++ b/src/main/java/com/example/bedwars/listeners/EditorListener.java
@@ -103,7 +103,10 @@ public final class EditorListener implements Listener {
         p.sendMessage(plugin.messages().get("editor.not-looking-bed"));
         return;
       }
-      plugin.arenas().setTeamBed(id, c, head);
+      Block hb = head.getBlock();
+      Bed bedData = (Bed) hb.getBlockData();
+      Block foot = hb.getRelative(bedData.getFacing().getOppositeFace());
+      plugin.arenas().setTeamBed(id, c, foot.getLocation());
       p.sendMessage(plugin.messages().format("editor.set-bed", Map.of("team", c.display)));
       plugin.menus().openEditor(EditorView.TEAM, p, id);
       return;

--- a/src/main/java/com/example/bedwars/services/BuildRulesService.java
+++ b/src/main/java/com/example/bedwars/services/BuildRulesService.java
@@ -47,10 +47,9 @@ public final class BuildRulesService {
   }
 
   public boolean isAllowed(Material mat) {
-    if (plugin.getConfig().getBoolean("build.allow_all_shop_blocks", true)) {
-      return dynamicAllowed.contains(mat);
-    }
-    return staticAllowed.contains(mat);
+    boolean dynamic = plugin.getConfig().getBoolean("build.allow_all_shop_blocks", true)
+        && dynamicAllowed.contains(mat);
+    return dynamic || staticAllowed.contains(mat);
   }
 
   public void recordPlacement(String arenaId, Location loc) {


### PR DESCRIPTION
## Summary
- Allow both static and shop-provided blocks for placement
- Store and match bed foot locations to let players break enemy beds
- Ignore cancelled build events and simplify protection checks

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d0ce05d948329af9c28272c5002a5