### PR TITLE
Safeguard arena world resets

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -81,6 +81,7 @@ public final class BedwarsPlugin extends JavaPlugin {
     saveResource("rotation.yml", false);
     this.rotationManager = new RotationManager(this);
     this.resetManager = new ResetManager(this);
+    this.resetManager.restoreWorldsOnEnable();
     this.menuManager = new MenuManager(this);
     this.promptService = new PromptService(this);
     this.shopConfig = new ShopConfig(this);

--- a/src/main/java/com/example/bedwars/util/DirUtils.java
+++ b/src/main/java/com/example/bedwars/util/DirUtils.java
@@ -1,0 +1,35 @@
+package com.example.bedwars.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/** Utility methods for directory operations. */
+public final class DirUtils {
+  private DirUtils() {}
+
+  public static void deleteDir(Path path) throws IOException {
+    if (!Files.exists(path)) return;
+    try (Stream<Path> s = Files.walk(path)) {
+      s.sorted(Comparator.reverseOrder()).forEach(p -> {
+        try { Files.delete(p); } catch (IOException ignored) {}
+      });
+    }
+  }
+
+  public static void copyDir(Path src, Path dest) throws IOException {
+    try (Stream<Path> s = Files.walk(src)) {
+      for (Path p : (Iterable<Path>) s::iterator) {
+        Path target = dest.resolve(src.relativize(p));
+        if (Files.isDirectory(p)) {
+          Files.createDirectories(target);
+        } else {
+          Files.copy(p, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -136,3 +136,6 @@ reset:
   lobby_world: "world"
   lobby_spawn: { x: 0, y: 100, z: 0, yaw: 0, pitch: 0 }
   templates_path: "plugins/Bedwars/templates"
+  runtime_prefix: "bw_"
+  atomic_copy: true
+  preserve_on_disable: true

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -176,6 +176,7 @@ reset:
   preparing: "&7Préparation du reset..."
   done: "&aReset terminé. Retour en &fWAITING"
   failed: "&cÉchec du reset: &f{error}"
+  restoring_at_start: "&7Restauration des mondes d'arène au démarrage..."
 forcestart:
   countdown: "&eLa partie démarre dans &6{sec}s"
   started: "&aLa partie commence !"


### PR DESCRIPTION
## Summary
- prevent arena worlds from vanishing by copying templates to a temp folder and atomically swapping runtime worlds
- restore missing arena worlds on startup and add config options for reset behaviour
- add directory utility helpers and startup reset message

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d0f97492c8329bfff0646a6e6f278