### PR TITLE
Fix wool placement and bed-breaking rules

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -106,11 +106,17 @@ compass:
 
 build:
   allow_all_shop_blocks: true
-  allowed_materials: [WHITE_WOOL, GLASS, STAINED_GLASS, END_STONE, OAK_PLANKS, HARDENED_CLAY]
   extra_allowed_materials: []
   require_permission: false
   bypass_external_protection: true
   worldguard_bypass: false
+  wool_all_colors_allowed: true
+  no_build:
+    npc_radius: 2.0
+    gen:
+      base_radius: 1.5
+      diamond_radius: 1.5
+      emerald_radius: 1.5
 
 shop:
   armor_persistent: true

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -9,6 +9,8 @@ errors:
   map_protected: "&cCarte protégée."
   own_bed: "&cTu ne peux pas casser ton propre lit !"
   bed_already_broken: "&eCe lit est déjà détruit."
+  no_build_npc: "&cImpossible de construire à côté d’un PNJ."
+  no_build_generator: "&cImpossible de construire sur un générateur."
 
 menu:
   title_admin: "&eMenu Admin"


### PR DESCRIPTION
## Summary
- allow all wool colors and shop blocks via expanded build rules
- block building near NPCs and generators with configurable radii
- prevent bed placement and properly handle bed destruction

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d14c6ca2883299c49e2fd5874c1a5