### PR TITLE
Implement gameplay protections and fireball mechanics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
       <version>1.21-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+      <version>8.5.12</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -18,6 +18,8 @@ import com.example.bedwars.listeners.DamageRulesListener;
 import com.example.bedwars.listeners.EntityExplodeListener;
 import com.example.bedwars.listeners.CompassListener;
 import com.example.bedwars.listeners.ArmorLockListener;
+import com.example.bedwars.listeners.GameplayListener;
+import com.example.bedwars.listeners.FireballListener;
 import com.example.bedwars.rules.BuildRulesListener;
 import com.example.bedwars.listeners.DeathListener;
 import com.example.bedwars.listeners.VoidFailSafeListener;
@@ -127,12 +129,14 @@ public final class BedwarsPlugin extends JavaPlugin {
     getServer().getPluginManager().registerEvents(new PlayerRespawnListener(contextService), this);
     getServer().getPluginManager().registerEvents(new BuildRulesListener(this, contextService, buildRules), this);
     getServer().getPluginManager().registerEvents(new DamageRulesListener(this, contextService), this);
-    getServer().getPluginManager().registerEvents(new EntityExplodeListener(buildRules), this);
+    getServer().getPluginManager().registerEvents(new EntityExplodeListener(this, buildRules), this);
     getServer().getPluginManager().registerEvents(new TntListener(this, contextService, buildRules), this);
     getServer().getPluginManager().registerEvents(teamSelectMenu, this);
     getServer().getPluginManager().registerEvents(new LobbyListener(this, lobbyItems, teamSelectMenu, contextService, gameService), this);
     getServer().getPluginManager().registerEvents(new CompassListener(this, contextService, teamSelectMenu), this);
     getServer().getPluginManager().registerEvents(new ArmorLockListener(this, contextService), this);
+    getServer().getPluginManager().registerEvents(new GameplayListener(this, contextService), this);
+    getServer().getPluginManager().registerEvents(new FireballListener(this, contextService), this);
 
     getLogger().info("Bedwars loaded.");
   }

--- a/src/main/java/com/example/bedwars/game/GameService.java
+++ b/src/main/java/com/example/bedwars/game/GameService.java
@@ -226,6 +226,9 @@ public final class GameService {
       spectator.fromSpectator(p);
     }
     plugin.generators().cleanupArena(a.id());
+    if (plugin.getConfig().getBoolean("reset.clear_placed_blocks_on_end", true)) {
+      plugin.buildRules().clearArenaBlocks(a);
+    }
     Integer timer = timerTasks.remove(a.id());
     if (timer != null) Bukkit.getScheduler().cancelTask(timer);
     gameTime.remove(a.id());

--- a/src/main/java/com/example/bedwars/listeners/ArmorLockListener.java
+++ b/src/main/java/com/example/bedwars/listeners/ArmorLockListener.java
@@ -5,11 +5,14 @@ import com.example.bedwars.game.PlayerContextService;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.Material;
 
-/** Prevents removing team armor from legs and feet slots. */
+/** Prevents removing team armor pieces from inventory. */
 public final class ArmorLockListener implements Listener {
   private final BedwarsPlugin plugin;
   private final PlayerContextService ctx;
@@ -19,7 +22,12 @@ public final class ArmorLockListener implements Listener {
   }
 
   private boolean enabled() {
-    return plugin.getConfig().getBoolean("armor.lock_legs_feet", true);
+    return plugin.getConfig().getBoolean("gameplay.lock_armor", true);
+  }
+
+  private static boolean isArmor(Material m) {
+    return m != null && (m.name().endsWith("_HELMET") || m.name().endsWith("_CHESTPLATE")
+        || m.name().endsWith("_LEGGINGS") || m.name().endsWith("_BOOTS"));
   }
 
   @EventHandler(ignoreCancelled = true)
@@ -29,8 +37,23 @@ public final class ArmorLockListener implements Listener {
     if (ctx.getArena(p) == null) return;
     if (!(e.getClickedInventory() instanceof PlayerInventory)) return;
     int slot = e.getSlot();
-    if (slot == 36 || slot == 37) {
+    if (slot >= 36 && slot <= 39) {
       e.setCancelled(true);
+      plugin.messages().send(p, "errors.cannot_remove_armor");
+      return;
+    }
+    if (e.isShiftClick()) {
+      ItemStack cur = e.getCurrentItem();
+      if (cur != null && isArmor(cur.getType())) {
+        e.setCancelled(true);
+        plugin.messages().send(p, "errors.cannot_remove_armor");
+      }
+    }
+    if (e.getClick() == ClickType.DROP || e.getClick() == ClickType.CONTROL_DROP) {
+      if (slot >= 36 && slot <= 39) {
+        e.setCancelled(true);
+        plugin.messages().send(p, "errors.cannot_remove_armor");
+      }
     }
   }
 
@@ -39,8 +62,10 @@ public final class ArmorLockListener implements Listener {
     if (!enabled()) return;
     if (!(e.getWhoClicked() instanceof Player p)) return;
     if (ctx.getArena(p) == null) return;
-    if (e.getRawSlots().contains(36) || e.getRawSlots().contains(37)) {
+    if (e.getRawSlots().stream().anyMatch(s -> s >= 36 && s <= 39)) {
       e.setCancelled(true);
+      if (e.getWhoClicked() instanceof Player p)
+        plugin.messages().send(p, "errors.cannot_remove_armor");
     }
   }
 }

--- a/src/main/java/com/example/bedwars/listeners/EntityExplodeListener.java
+++ b/src/main/java/com/example/bedwars/listeners/EntityExplodeListener.java
@@ -1,21 +1,31 @@
 package com.example.bedwars.listeners;
 
+import com.example.bedwars.BedwarsPlugin;
 import com.example.bedwars.services.BuildRulesService;
 import org.bukkit.Tag;
+import org.bukkit.entity.Fireball;
+import org.bukkit.entity.SmallFireball;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
 /** Filters explosion damage to only affect player-placed blocks. */
 public final class EntityExplodeListener implements Listener {
+  private final BedwarsPlugin plugin;
   private final BuildRulesService buildRules;
 
-  public EntityExplodeListener(BuildRulesService br) {
+  public EntityExplodeListener(BedwarsPlugin plugin, BuildRulesService br) {
+    this.plugin = plugin;
     this.buildRules = br;
   }
 
   @EventHandler(ignoreCancelled = true)
   public void onExplode(EntityExplodeEvent e) {
+    boolean isFireball = e.getEntity() instanceof Fireball || e.getEntity() instanceof SmallFireball;
+    boolean restrict = isFireball
+        ? plugin.getConfig().getBoolean("fireball.break_only_player_blocks", true)
+        : plugin.getConfig().getBoolean("rules.break-only-placed", true);
+    if (!restrict) return;
     e.blockList().removeIf(b -> {
       if (Tag.BEDS.isTagged(b.getType())) return true;
       if (!b.hasMetadata("bw_placed")) return true;

--- a/src/main/java/com/example/bedwars/listeners/FireballListener.java
+++ b/src/main/java/com/example/bedwars/listeners/FireballListener.java
@@ -1,0 +1,88 @@
+package com.example.bedwars.listeners;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.GameState;
+import com.example.bedwars.game.PlayerContextService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.bukkit.entity.Fireball;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.SmallFireball;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.Vector;
+
+/** Handles usage of fireball items from the shop. */
+public final class FireballListener implements Listener {
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService ctx;
+  private final Map<UUID, Long> cooldown = new HashMap<>();
+
+  public FireballListener(BedwarsPlugin plugin, PlayerContextService ctx) {
+    this.plugin = plugin;
+    this.ctx = ctx;
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onInteract(PlayerInteractEvent e) {
+    if (!plugin.getConfig().getBoolean("fireball.enabled", true)) return;
+    if (e.getHand() != EquipmentSlot.HAND) return;
+    ItemStack it = e.getItem();
+    if (it == null) return;
+    ItemMeta meta = it.getItemMeta();
+    if (meta == null) return;
+    String tag = meta.getPersistentDataContainer().get(plugin.keys().BW_ITEM(), PersistentDataType.STRING);
+    if (!"fireball".equalsIgnoreCase(tag)) return;
+    Action act = e.getAction();
+    if (act != Action.RIGHT_CLICK_AIR && act != Action.RIGHT_CLICK_BLOCK) return;
+
+    Player p = e.getPlayer();
+    String arenaId = ctx.getArena(p);
+    if (arenaId == null) return;
+    Arena a = plugin.arenas().get(arenaId).orElse(null);
+    if (a == null || a.state() != GameState.RUNNING) return;
+
+    long now = System.currentTimeMillis();
+    long end = cooldown.getOrDefault(p.getUniqueId(), 0L);
+    if (end > now) {
+      plugin.messages().send(p, "fireball.cooldown");
+      e.setCancelled(true);
+      return;
+    }
+
+    e.setCancelled(true);
+    // consume one item
+    it.setAmount(it.getAmount() - 1);
+    if (it.getAmount() <= 0) {
+      p.getInventory().setItemInMainHand(null);
+    } else {
+      p.getInventory().setItemInMainHand(it);
+    }
+
+    double speed = plugin.getConfig().getDouble("fireball.speed", 1.2);
+    boolean incendiary = plugin.getConfig().getBoolean("fireball.incendiary", false);
+    double yield = plugin.getConfig().getDouble("fireball.explosion_yield", 2.5);
+    Vector dir = p.getEyeLocation().getDirection().normalize().multiply(speed);
+    String type = plugin.getConfig().getString("fireball.type", "BIG");
+    if ("SMALL".equalsIgnoreCase(type)) {
+      SmallFireball sf = p.launchProjectile(SmallFireball.class, dir);
+      sf.setIsIncendiary(incendiary);
+    } else {
+      Fireball f = p.launchProjectile(Fireball.class, dir);
+      f.setIsIncendiary(incendiary);
+      f.setYield((float) yield);
+    }
+
+    long cd = plugin.getConfig().getLong("fireball.cooldown_ticks", 20);
+    cooldown.put(p.getUniqueId(), now + cd * 50L);
+  }
+}
+

--- a/src/main/java/com/example/bedwars/listeners/GameplayListener.java
+++ b/src/main/java/com/example/bedwars/listeners/GameplayListener.java
@@ -1,0 +1,72 @@
+package com.example.bedwars.listeners;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.game.PlayerContextService;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.inventory.ItemStack;
+
+/** Misc gameplay restrictions: sword drop and hunger. */
+public final class GameplayListener implements Listener {
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService ctx;
+
+  public GameplayListener(BedwarsPlugin plugin, PlayerContextService ctx) {
+    this.plugin = plugin;
+    this.ctx = ctx;
+  }
+
+  private boolean noDropSwords() {
+    return plugin.getConfig().getBoolean("gameplay.no_drop_swords", true);
+  }
+
+  private boolean noHunger() {
+    return plugin.getConfig().getBoolean("gameplay.no_hunger", true);
+  }
+
+  private static boolean isSword(Material m) {
+    return m != null && m.name().endsWith("_SWORD");
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onDrop(PlayerDropItemEvent e) {
+    if (!noDropSwords()) return;
+    Player p = e.getPlayer();
+    if (ctx.getArena(p) == null) return;
+    if (isSword(e.getItemDrop().getItemStack().getType())) {
+      e.setCancelled(true);
+      plugin.messages().send(p, "errors.cannot_drop_sword");
+    }
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onInvClick(InventoryClickEvent e) {
+    if (!noDropSwords()) return;
+    if (!(e.getWhoClicked() instanceof Player p)) return;
+    if (ctx.getArena(p) == null) return;
+    if (e.getClick() == ClickType.DROP || e.getClick() == ClickType.CONTROL_DROP) {
+      ItemStack cur = e.getCurrentItem();
+      if (cur != null && isSword(cur.getType())) {
+        e.setCancelled(true);
+        plugin.messages().send(p, "errors.cannot_drop_sword");
+      }
+    }
+  }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onFood(FoodLevelChangeEvent e) {
+    if (!noHunger()) return;
+    if (!(e.getEntity() instanceof Player p)) return;
+    if (ctx.getArena(p) == null) return;
+    e.setCancelled(true);
+    p.setFoodLevel(20);
+    p.setSaturation(20f);
+  }
+}
+

--- a/src/main/java/com/example/bedwars/rules/BuildRulesListener.java
+++ b/src/main/java/com/example/bedwars/rules/BuildRulesListener.java
@@ -80,8 +80,10 @@ public final class BuildRulesListener implements Listener {
       plugin.messages().send(p, "errors.map_protected");
       return;
     }
-    e.getBlockPlaced().setMetadata("bw_placed", new FixedMetadataValue(plugin, true));
-    buildRules.recordPlacement(arenaId, e.getBlockPlaced().getLocation());
+    if (plugin.getConfig().getBoolean("build.track_placed_blocks", true)) {
+      e.getBlockPlaced().setMetadata("bw_placed", new FixedMetadataValue(plugin, true));
+      buildRules.recordPlacement(arenaId, e.getBlockPlaced().getLocation());
+    }
   }
 
   @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -138,11 +140,13 @@ public final class BuildRulesListener implements Listener {
       return;
     }
 
+    boolean track = plugin.getConfig().getBoolean("build.track_placed_blocks", true);
     if (plugin.getConfig().getBoolean("rules.break-only-placed", true)
+        && track
         && !buildRules.wasPlaced(arenaId, b.getLocation())) {
       e.setCancelled(true);
       plugin.messages().send(p, "errors.map_protected");
-    } else {
+    } else if (track) {
       b.removeMetadata("bw_placed", plugin);
       buildRules.removePlaced(arenaId, b.getLocation());
     }

--- a/src/main/java/com/example/bedwars/services/BuildRulesService.java
+++ b/src/main/java/com/example/bedwars/services/BuildRulesService.java
@@ -4,6 +4,7 @@ import com.example.bedwars.BedwarsPlugin;
 import com.example.bedwars.shop.ShopCategory;
 import com.example.bedwars.shop.ShopConfig;
 import com.example.bedwars.shop.ShopItem;
+import com.example.bedwars.arena.Arena;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -74,5 +75,10 @@ public final class BuildRulesService {
 
   public void clearArena(String arenaId) {
     placed.clearArena(arenaId);
+  }
+
+  /** Clear and remove all player placed blocks in the arena world. */
+  public void clearArenaBlocks(Arena arena) {
+    placed.clearAll(plugin, arena);
   }
 }

--- a/src/main/java/com/example/bedwars/shop/ShopConfig.java
+++ b/src/main/java/com/example/bedwars/shop/ShopConfig.java
@@ -76,6 +76,7 @@ public final class ShopConfig {
 
         int amount = asInt(raw.get("amount"), 1);
         boolean perm = asBool(raw.get("permanent"), false);
+        String bwItem = asString(raw.get("bw_item"), "");
 
         Map<String,Object> costMap = asMap(raw.get("cost"));
         int cost = 0;
@@ -93,7 +94,8 @@ public final class ShopConfig {
             .cost(cost)
             .teamColored(teamCol)
             .permanent(perm)
-            .mat(mat);
+            .mat(mat)
+            .bwItem(bwItem);
 
         Map<String,Object> enchMap = asMap(raw.get("enchants"));
         if (enchMap != null) {

--- a/src/main/java/com/example/bedwars/shop/ShopItem.java
+++ b/src/main/java/com/example/bedwars/shop/ShopItem.java
@@ -21,6 +21,7 @@ public final class ShopItem {
   public final String name;
   public final boolean teamColored;
   public final boolean permanent;
+  public final String bwItem;
 
   private ShopItem(
       String id,
@@ -31,7 +32,8 @@ public final class ShopItem {
       Map<Enchantment, Integer> enchants,
       String name,
       boolean teamColored,
-      boolean permanent) {
+      boolean permanent,
+      String bwItem) {
 
     this.id = Objects.requireNonNull(id, "id");
     this.mat = Objects.requireNonNull(mat, "mat");
@@ -42,6 +44,7 @@ public final class ShopItem {
     this.name = Objects.requireNonNullElse(name, "");
     this.teamColored = teamColored;
     this.permanent = permanent;
+    this.bwItem = Objects.requireNonNullElse(bwItem, "");
   }
 
   // ---------- Builder ----------
@@ -57,6 +60,7 @@ public final class ShopItem {
     private String name = "";
     private boolean teamColored = false;
     private boolean permanent = false;
+    private String bwItem = "";
 
     public Builder id(String id) { this.id = id; return this; }
     public Builder mat(Material m) { this.mat = m; return this; }
@@ -67,10 +71,11 @@ public final class ShopItem {
     public Builder name(String n) { this.name = n; return this; }
     public Builder teamColored(boolean yes) { this.teamColored = yes; return this; }
     public Builder permanent(boolean yes) { this.permanent = yes; return this; }
+    public Builder bwItem(String tag) { this.bwItem = tag; return this; }
 
     public ShopItem build() {
       if (id == null || id.isBlank()) throw new IllegalStateException("ShopItem id is required");
-      return new ShopItem(id, mat, amount, currency, cost, enchants, name, teamColored, permanent);
+      return new ShopItem(id, mat, amount, currency, cost, enchants, name, teamColored, permanent, bwItem);
     }
   }
 }

--- a/src/main/java/com/example/bedwars/shop/ShopListener.java
+++ b/src/main/java/com/example/bedwars/shop/ShopListener.java
@@ -80,6 +80,11 @@ public final class ShopListener implements Listener {
         Material mat = si.teamColored ? ih.team.wool : si.mat;
         ItemStack it = new ItemStack(mat, si.amount);
         si.enchants.forEach((en,l)-> it.addEnchantment(en,l));
+        if (si.bwItem != null && !si.bwItem.isBlank()) {
+          var meta = it.getItemMeta();
+          meta.getPersistentDataContainer().set(plugin.keys().BW_ITEM(), PersistentDataType.STRING, si.bwItem);
+          it.setItemMeta(meta);
+        }
         if (mat.name().endsWith("_SWORD")) {
           for (int i = 0; i < p.getInventory().getSize(); i++) {
             ItemStack cur = p.getInventory().getItem(i);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -98,7 +98,6 @@ kit:
 
 armor:
   dye_colored: true
-  lock_legs_feet: true
 
 compass:
   opens: rules   # rules | team_selector
@@ -111,6 +110,7 @@ build:
   bypass_external_protection: true
   worldguard_bypass: false
   wool_all_colors_allowed: true
+  track_placed_blocks: true
   no_build:
     npc_radius: 2.0
     gen:
@@ -124,6 +124,20 @@ shop:
 tnt:
   fuse_ticks: 40
   attribute_owner: true
+
+gameplay:
+  lock_armor: true
+  no_drop_swords: true
+  no_hunger: true
+
+fireball:
+  enabled: true
+  type: BIG        # BIG | SMALL
+  speed: 1.2
+  explosion_yield: 2.5
+  incendiary: false
+  break_only_player_blocks: true
+  cooldown_ticks: 20
 
 lobby:
   team_selector:
@@ -145,3 +159,4 @@ reset:
   runtime_prefix: "bw_"
   atomic_copy: true
   preserve_on_disable: true
+  clear_placed_blocks_on_end: true

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -11,6 +11,8 @@ errors:
   bed_already_broken: "&eCe lit est déjà détruit."
   no_build_npc: "&cImpossible de construire à côté d’un PNJ."
   no_build_generator: "&cImpossible de construire sur un générateur."
+  cannot_remove_armor: "&cTu ne peux pas enlever ton armure."
+  cannot_drop_sword: "&cTu ne peux pas jeter ton épée."
 
 menu:
   title_admin: "&eMenu Admin"
@@ -173,6 +175,9 @@ build:
 rotation:
   picking: "&7Sélection de la prochaine arène..."
   picked: "&aArène suivante: &f{arena}"
+
+fireball:
+  cooldown: "&ePatiente un instant avant de renvoyer une boule de feu."
 
 reset:
   preparing: "&7Préparation du reset..."

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -79,6 +79,7 @@ categories:
       name: "&fBoule de feu"
       material: FIRE_CHARGE
       cost: { currency: IRON, amount: 40 }
+      bw_item: fireball
     - id: TNT
       name: "&fTNT"
       material: TNT


### PR DESCRIPTION
## Summary
- track player-placed blocks and wipe them on game end
- lock all armor pieces, block sword drops, and stop hunger loss
- add shop fireball item with cooldown and filtered explosions

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d1979481083298f3aa08e2a1b8869