### PR TITLE
Fix world resolution and duplicated player variable

### DIFF
--- a/src/main/java/com/example/bedwars/listeners/ArmorLockListener.java
+++ b/src/main/java/com/example/bedwars/listeners/ArmorLockListener.java
@@ -64,8 +64,7 @@ public final class ArmorLockListener implements Listener {
     if (ctx.getArena(p) == null) return;
     if (e.getRawSlots().stream().anyMatch(s -> s >= 36 && s <= 39)) {
       e.setCancelled(true);
-      if (e.getWhoClicked() instanceof Player p)
-        plugin.messages().send(p, "errors.cannot_remove_armor");
+      plugin.messages().send(p, "errors.cannot_remove_armor");
     }
   }
 }

--- a/src/main/java/com/example/bedwars/services/PlacedBlocksStore.java
+++ b/src/main/java/com/example/bedwars/services/PlacedBlocksStore.java
@@ -4,6 +4,7 @@ import com.example.bedwars.arena.Arena;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -61,7 +62,7 @@ public final class PlacedBlocksStore {
   public void clearAll(JavaPlugin plugin, Arena a) {
     LongOpenHashSet set = byArena.get(a.id());
     if (set == null || set.isEmpty()) return;
-    World w = a.world();
+    World w = Bukkit.getWorld(a.world().name());
     for (long k : set) {
       int x = (int) (k >> 38);
       int y = (int) ((k >> 26) & 0xFFF);


### PR DESCRIPTION
## Summary
- Resolve Bukkit world from `Arena#world()` when clearing placed blocks
- Remove redundant player variable declaration in `ArmorLockListener`

## Testing
- `mvn -e package` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d1cb6aef88329987240d9bcee393f