### PR TITLE
Ensure shop NPCs return after arena reset

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -5,6 +5,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import com.example.bedwars.util.Messages;
 import com.example.bedwars.command.BwCommand;
 import com.example.bedwars.command.BwAdminCommand;
+import com.example.bedwars.arena.Arena;
 import com.example.bedwars.arena.ArenaManager;
 import com.example.bedwars.gui.MenuManager;
 import com.example.bedwars.ops.Keys;
@@ -40,6 +41,7 @@ import com.example.bedwars.game.GameMessages;
 import com.example.bedwars.game.GameService;
 import com.example.bedwars.game.DeathRespawnService;
 import com.example.bedwars.gen.GeneratorManager;
+import com.example.bedwars.shop.NpcManager;
 import com.example.bedwars.services.BuildRulesService;
 import com.example.bedwars.services.TasksService;
 import com.example.bedwars.game.RotationManager;
@@ -57,6 +59,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   private PlayerContextService contextService;
   private UpgradeService upgradeService;
   private GeneratorManager generatorManager;
+  private NpcManager npcManager;
   private TeamAssignment teamAssignment;
   private KitService kitService;
   private SpectatorService spectatorService;
@@ -102,6 +105,10 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.buildRules.rebuildWhitelistFromShop(shopConfig);
     this.generatorManager = new GeneratorManager(this);
     this.generatorManager.start();
+    this.npcManager = new NpcManager(this);
+    for (Arena a : this.arenaManager.all()) {
+      this.npcManager.ensureSpawned(a);
+    }
     this.tasksService = new TasksService(this);
 
     this.actionBarBus = new com.example.bedwars.hud.ActionBarBus();
@@ -144,6 +151,9 @@ public final class BedwarsPlugin extends JavaPlugin {
   @Override
   public void onDisable() {
     if (arenaManager != null) arenaManager.saveAll();
+    if (npcManager != null) {
+      arenaManager.all().forEach(npcManager::despawnAll);
+    }
     if (generatorManager != null) generatorManager.stop();
     if (scoreboardManager != null) scoreboardManager.clear();
     getLogger().info("Bedwars disabled.");
@@ -184,6 +194,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   public PlayerContextService contexts() { return contextService; }
   public UpgradeService upgrades() { return upgradeService; }
   public GeneratorManager generators() { return generatorManager; }
+  public NpcManager npcs() { return npcManager; }
   public GameService game() { return gameService; }
   public BuildRulesService buildRules() { return buildRules; }
   public com.example.bedwars.hud.ScoreboardManager scoreboard() { return scoreboardManager; }

--- a/src/main/java/com/example/bedwars/command/BwAdminCommand.java
+++ b/src/main/java/com/example/bedwars/command/BwAdminCommand.java
@@ -56,6 +56,15 @@ public final class BwAdminCommand implements CommandExecutor {
       return true;
     }
 
+    if (args[0].equalsIgnoreCase("npc")) {
+      if (!sender.hasPermission("bedwars.admin.npc")) {
+        sender.sendMessage(plugin.messages().get("errors.no_perm"));
+        return true;
+      }
+      handleNpc(sender, args);
+      return true;
+    }
+
     if (args[0].equalsIgnoreCase("debug")) {
       handleDebug(sender, args);
       return true;
@@ -99,6 +108,38 @@ public final class BwAdminCommand implements CommandExecutor {
         }
       }
       default -> sender.sendMessage(plugin.messages().get("prefix") + "Usage: /bwadmin game <start|stop|forcewin> <arena> [team]");
+    }
+  }
+
+  private void handleNpc(CommandSender sender, String[] args) {
+    String prefix = plugin.messages().get("prefix");
+    if (args.length < 3) {
+      sender.sendMessage(prefix + "Usage: /bwadmin npc <respawn|list> <arena>");
+      return;
+    }
+    String sub = args[1].toLowerCase();
+    String arenaId = args[2];
+    var opt = plugin.arenas().get(arenaId);
+    if (opt.isEmpty()) {
+      msg(sender, "errors.arena_unknown", Map.of("arena", arenaId));
+      return;
+    }
+    var arena = opt.get();
+    switch (sub) {
+      case "respawn" -> {
+        plugin.npcs().despawnAll(arena);
+        plugin.npcs().ensureSpawned(arena);
+        sender.sendMessage(prefix + "PNJ respawnés.");
+      }
+      case "list" -> {
+        var list = plugin.npcs().list(arena);
+        sender.sendMessage(prefix + "PNJ actifs: " + list.size());
+        for (var e : list) {
+          var l = e.getLocation();
+          sender.sendMessage(String.format(" - %s @ %.1f %.1f %.1f", e.getType().name(), l.getX(), l.getY(), l.getZ()));
+        }
+      }
+      default -> sender.sendMessage(prefix + "Usage: /bwadmin npc <respawn|list> <arena>");
     }
   }
 

--- a/src/main/java/com/example/bedwars/game/GameService.java
+++ b/src/main/java/com/example/bedwars/game/GameService.java
@@ -263,6 +263,7 @@ public final class GameService {
       } else {
         target.setState(GameState.WAITING);
         plugin.messages().broadcast(a, "reset.done");
+        plugin.npcs().ensureSpawned(target);
       }
     }));
   }

--- a/src/main/java/com/example/bedwars/shop/NpcManager.java
+++ b/src/main/java/com/example/bedwars/shop/NpcManager.java
@@ -1,0 +1,91 @@
+package com.example.bedwars.shop;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import java.util.ArrayList;
+import java.util.List;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Villager;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * Handles spawning and cleanup of shop/upgrade NPCs.
+ */
+public final class NpcManager {
+  private final BedwarsPlugin plugin;
+
+  public NpcManager(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+  }
+
+  /** Ensure NPCs for the given arena are spawned next tick. */
+  public void ensureSpawned(Arena arena) {
+    Bukkit.getScheduler().runTask(plugin, () -> spawnAll(arena));
+  }
+
+  /** Spawn all NPCs configured for the arena. */
+  public void spawnAll(Arena arena) {
+    World w = Bukkit.getWorld(arena.world().name());
+    if (w == null) return;
+    for (NpcData def : arena.npcs()) {
+      Location loc = def.location();
+      Chunk c = loc.getChunk();
+      if (!c.isLoaded()) c.load();
+      Villager v = (Villager) w.spawnEntity(loc, EntityType.VILLAGER);
+      v.setAI(false);
+      v.setInvulnerable(true);
+      v.setCollidable(false);
+      v.setGravity(false);
+      v.setCanPickupItems(false);
+      v.setRemoveWhenFarAway(false);
+      switch (def.type()) {
+        case ITEM -> v.setCustomName(org.bukkit.ChatColor.GREEN + "Objets");
+        case UPGRADE -> v.setCustomName(org.bukkit.ChatColor.AQUA + "Améliorations");
+      }
+      v.setCustomNameVisible(true);
+      var pdc = v.getPersistentDataContainer();
+      pdc.set(plugin.keys().ARENA_ID(), PersistentDataType.STRING, arena.id());
+      pdc.set(plugin.keys().NPC_KIND(), PersistentDataType.STRING, def.type().name().toLowerCase());
+    }
+  }
+
+  /** Remove all NPCs tagged for the arena. */
+  public void despawnAll(Arena arena) {
+    World w = Bukkit.getWorld(arena.world().name());
+    if (w == null) return;
+    NamespacedKey arenaKey = plugin.keys().ARENA_ID();
+    NamespacedKey npcKey = plugin.keys().NPC_KIND();
+    for (Entity e : new ArrayList<>(w.getEntities())) {
+      if (e instanceof org.bukkit.entity.Player) continue;
+      var pdc = e.getPersistentDataContainer();
+      String aId = pdc.get(arenaKey, PersistentDataType.STRING);
+      if (arena.id().equals(aId) && pdc.has(npcKey, PersistentDataType.STRING)) {
+        e.remove();
+      }
+    }
+  }
+
+  /** List all active NPC entities for the arena. */
+  public List<Entity> list(Arena arena) {
+    World w = Bukkit.getWorld(arena.world().name());
+    if (w == null) return List.of();
+    NamespacedKey arenaKey = plugin.keys().ARENA_ID();
+    NamespacedKey npcKey = plugin.keys().NPC_KIND();
+    List<Entity> out = new ArrayList<>();
+    for (Entity e : w.getEntities()) {
+      if (e instanceof org.bukkit.entity.Player) continue;
+      var pdc = e.getPersistentDataContainer();
+      String aId = pdc.get(arenaKey, PersistentDataType.STRING);
+      if (arena.id().equals(aId) && pdc.has(npcKey, PersistentDataType.STRING)) {
+        out.add(e);
+      }
+    }
+    return out;
+  }
+}


### PR DESCRIPTION
## Summary
- add NpcManager to spawn, clean up and list arena shop NPCs
- spawn NPCs on plugin enable and after arena resets
- add `/bwadmin npc` commands for respawn and listing

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1... Network is unreachable)*
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d89ac68448329b3fdc5a4013bb4be