### PR TITLE
fix: stabilize arena lighting

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -40,6 +40,7 @@ import com.example.bedwars.game.SpectatorService;
 import com.example.bedwars.game.GameMessages;
 import com.example.bedwars.game.GameService;
 import com.example.bedwars.game.DeathRespawnService;
+import com.example.bedwars.game.LightingService;
 import com.example.bedwars.gen.GeneratorManager;
 import com.example.bedwars.shop.NpcManager;
 import com.example.bedwars.services.BuildRulesService;
@@ -65,6 +66,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   private SpectatorService spectatorService;
   private GameMessages gameMessages;
   private GameService gameService;
+  private LightingService lightingService;
   private BuildRulesService buildRules;
   private DeathRespawnService deathService;
   private LobbyItemsService lobbyItems;
@@ -97,6 +99,11 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.gameMessages = new GameMessages(this, contextService);
     this.lobbyItems = new LobbyItemsService(this);
     this.teamSelectMenu = new TeamSelectMenu(this, contextService);
+    this.lightingService = new LightingService(this);
+    for (Arena a : this.arenaManager.all()) {
+      this.lightingService.applyDayClear(a);
+      this.lightingService.relightArena(a);
+    }
     this.gameService = new GameService(this, contextService, teamAssignment, kitService, spectatorService, gameMessages, lobbyItems);
     this.deathService = new DeathRespawnService(this, contextService, kitService, spectatorService, gameMessages, gameService);
     this.gameService.setDeathService(deathService);
@@ -196,6 +203,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   public GeneratorManager generators() { return generatorManager; }
   public NpcManager npcs() { return npcManager; }
   public GameService game() { return gameService; }
+  public LightingService lighting() { return lightingService; }
   public BuildRulesService buildRules() { return buildRules; }
   public com.example.bedwars.hud.ScoreboardManager scoreboard() { return scoreboardManager; }
   public com.example.bedwars.hud.ActionBarBus actionBar() { return actionBarBus; }

--- a/src/main/java/com/example/bedwars/game/GameService.java
+++ b/src/main/java/com/example/bedwars/game/GameService.java
@@ -109,6 +109,7 @@ public final class GameService {
     p.getInventory().clear();
     if (a.lobby() != null) p.teleport(a.lobby());
     lobbyItems.giveLobbyItems(p);
+    plugin.lighting().sanitizePlayer(p);
     messages.send(p, "player.joined_arena", Map.of("arena", arenaId));
 
     int count = contexts.countPlayers(arenaId);
@@ -164,6 +165,7 @@ public final class GameService {
   private void beginRunning(Arena a) {
     a.setState(GameState.RUNNING);
     Bukkit.getPluginManager().callEvent(new ArenaStateChangeEvent(a, GameState.STARTING, GameState.RUNNING));
+    plugin.lighting().applyDayClear(a);
     for (Player p : contexts.playersInArena(a.id())) {
       TeamColor team = contexts.getTeam(p);
       if (team == null) team = teamAssignment.assign(a, p);
@@ -262,6 +264,8 @@ public final class GameService {
         plugin.messages().broadcast(a, "reset.failed", Map.of("error", err.getCause().getMessage()));
       } else {
         target.setState(GameState.WAITING);
+        plugin.lighting().applyDayClear(target);
+        plugin.lighting().relightArena(target);
         plugin.messages().broadcast(a, "reset.done");
         plugin.npcs().ensureSpawned(target);
       }

--- a/src/main/java/com/example/bedwars/game/LightingService.java
+++ b/src/main/java/com/example/bedwars/game/LightingService.java
@@ -1,0 +1,149 @@
+package com.example.bedwars.game;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.GameState;
+import com.example.bedwars.arena.TeamData;
+import com.example.bedwars.gen.Generator;
+import com.example.bedwars.shop.NpcData;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.GameRule;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Handles lighting and time/weather consistency for arenas.
+ */
+public final class LightingService {
+  private final BedwarsPlugin plugin;
+
+  public LightingService(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+    // periodic sanity to remove blindness and optionally give night vision
+    Bukkit.getScheduler().runTaskTimer(plugin, this::tick, 100L, 100L);
+  }
+
+  /** Apply day time and clear weather according to config. */
+  public void applyDayClear(Arena a) {
+    World w = requireWorld(a);
+    var cfg = plugin.getConfig();
+    if (cfg.getBoolean("lighting.force_day", true)) {
+      w.setTime(cfg.getLong("lighting.day_time", 6000L));
+    }
+    if (cfg.getBoolean("lighting.lock_day", true)) {
+      w.setGameRule(GameRule.DO_DAYLIGHT_CYCLE, false);
+    }
+    if (cfg.getBoolean("lighting.clear_weather", true)) {
+      w.setStorm(false);
+      w.setThundering(false);
+      w.setGameRule(GameRule.DO_WEATHER_CYCLE, false);
+    }
+  }
+
+  /** Relight all chunks for an arena after world (re)load. */
+  public void relightArena(Arena a) {
+    if (!plugin.getConfig().getBoolean("lighting.relight_on_world_load", true)) return;
+    World w = requireWorld(a);
+    for (Chunk c : getArenaChunks(a)) {
+      if (!c.isLoaded()) c.load();
+      relightChunk(c);
+    }
+  }
+
+  private void relightChunk(Chunk c) {
+    World w = c.getWorld();
+    int y = w.getMaxHeight() - 2;
+    int[] coords = {0, 15};
+    for (int x : coords) {
+      for (int z : coords) {
+        Block b = c.getBlock(x, y, z);
+        Material m = b.getType();
+        if (m != Material.LIGHT) {
+          b.setType(Material.LIGHT, false);
+          b.setType(m, false);
+        }
+      }
+    }
+    w.refreshChunk(c.getX(), c.getZ());
+  }
+
+  /** Remove blindness/darkness and optionally grant night vision. */
+  public void sanitizePlayer(Player p) {
+    p.removePotionEffect(PotionEffectType.BLINDNESS);
+    try {
+      PotionEffectType darkness = PotionEffectType.valueOf("DARKNESS");
+      p.removePotionEffect(darkness);
+    } catch (IllegalArgumentException ignored) {}
+    if (plugin.getConfig().getBoolean("lighting.waiting_night_vision", false) && isWaiting(p)) {
+      PotionEffect nv = new PotionEffect(PotionEffectType.NIGHT_VISION, 20 * 30, 0, true, false);
+      p.addPotionEffect(nv);
+    }
+  }
+
+  private void tick() {
+    for (Player p : Bukkit.getOnlinePlayers()) {
+      if (plugin.contexts().isInArena(p)) sanitizePlayer(p);
+    }
+  }
+
+  private boolean isWaiting(Player p) {
+    String arenaId = plugin.contexts().getArena(p);
+    if (arenaId == null) return false;
+    Arena a = plugin.arenas().get(arenaId).orElse(null);
+    return a != null && a.state() == GameState.WAITING;
+  }
+
+  private World requireWorld(Arena a) {
+    World w = Bukkit.getWorld(a.world().name());
+    if (w == null) throw new IllegalStateException("World not loaded for arena " + a.id());
+    return w;
+  }
+
+  private Collection<Chunk> getArenaChunks(Arena a) {
+    World w = requireWorld(a);
+    int minX = Integer.MAX_VALUE, maxX = Integer.MIN_VALUE;
+    int minZ = Integer.MAX_VALUE, maxZ = Integer.MIN_VALUE;
+    boolean found = false;
+    List<Location> locs = new ArrayList<>();
+    if (a.lobby() != null) locs.add(a.lobby());
+    for (TeamData td : a.teams().values()) {
+      if (td.spawn() != null) locs.add(td.spawn());
+      if (td.bedBlock() != null) locs.add(td.bedBlock());
+    }
+    for (Generator g : a.generators()) locs.add(g.location());
+    for (NpcData n : a.npcs()) locs.add(n.location());
+    for (Location l : locs) {
+      if (l.getWorld() != w) continue;
+      int cx = l.getBlockX() >> 4;
+      int cz = l.getBlockZ() >> 4;
+      if (cx < minX) minX = cx;
+      if (cx > maxX) maxX = cx;
+      if (cz < minZ) minZ = cz;
+      if (cz > maxZ) maxZ = cz;
+      found = true;
+    }
+    Set<Chunk> chunks = new HashSet<>();
+    if (!found) {
+      for (Chunk c : w.getLoadedChunks()) chunks.add(c);
+      return chunks;
+    }
+    for (int x = minX; x <= maxX; x++) {
+      for (int z = minZ; z <= maxZ; z++) {
+        chunks.add(w.getChunkAt(x, z));
+      }
+    }
+    return chunks;
+  }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -160,3 +160,11 @@ reset:
   atomic_copy: true
   preserve_on_disable: true
   clear_placed_blocks_on_end: true
+
+lighting:
+  force_day: true
+  day_time: 6000
+  lock_day: true
+  clear_weather: true
+  relight_on_world_load: true
+  waiting_night_vision: false


### PR DESCRIPTION
## Summary
- ensure arenas stay bright by locking time, weather and relighting chunks
- purge blindness effects and optionally grant night vision during waiting
- add lighting settings section to config

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d8d2ce8e08329ba7b07834ac1f8bd