### PR TITLE
feat: add per-arena world border

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -47,6 +47,10 @@ import com.example.bedwars.services.BuildRulesService;
 import com.example.bedwars.services.TasksService;
 import com.example.bedwars.game.RotationManager;
 import com.example.bedwars.game.ResetManager;
+import com.example.bedwars.border.BorderService;
+import com.example.bedwars.border.BorderMoveListener;
+import com.example.bedwars.border.BorderBuildListener;
+import com.example.bedwars.border.BorderStateListener;
 
 public final class BedwarsPlugin extends JavaPlugin {
 
@@ -76,6 +80,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   private RotationManager rotationManager;
   private ResetManager resetManager;
   private TasksService tasksService;
+  private BorderService borderService;
 
   @Override
   public void onEnable() {
@@ -100,9 +105,11 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.lobbyItems = new LobbyItemsService(this);
     this.teamSelectMenu = new TeamSelectMenu(this, contextService);
     this.lightingService = new LightingService(this);
+    this.borderService = new BorderService(this);
     for (Arena a : this.arenaManager.all()) {
       this.lightingService.applyDayClear(a);
       this.lightingService.relightArena(a);
+      this.borderService.apply(a);
     }
     this.gameService = new GameService(this, contextService, teamAssignment, kitService, spectatorService, gameMessages, lobbyItems);
     this.deathService = new DeathRespawnService(this, contextService, kitService, spectatorService, gameMessages, gameService);
@@ -151,6 +158,9 @@ public final class BedwarsPlugin extends JavaPlugin {
     getServer().getPluginManager().registerEvents(new ArmorLockListener(this, contextService), this);
     getServer().getPluginManager().registerEvents(new GameplayListener(this, contextService), this);
     getServer().getPluginManager().registerEvents(new FireballListener(this, contextService), this);
+    getServer().getPluginManager().registerEvents(new BorderMoveListener(this, contextService, borderService), this);
+    getServer().getPluginManager().registerEvents(new BorderBuildListener(this, contextService, borderService), this);
+    getServer().getPluginManager().registerEvents(new BorderStateListener(borderService), this);
 
     getLogger().info("Bedwars loaded.");
   }
@@ -210,4 +220,5 @@ public final class BedwarsPlugin extends JavaPlugin {
   public RotationManager rotation() { return rotationManager; }
   public ResetManager reset() { return resetManager; }
   public TasksService tasks() { return tasksService; }
+  public BorderService border() { return borderService; }
 }

--- a/src/main/java/com/example/bedwars/border/BorderBuildListener.java
+++ b/src/main/java/com/example/bedwars/border/BorderBuildListener.java
@@ -1,0 +1,57 @@
+package com.example.bedwars.border;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.game.PlayerContextService;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+/** Listener preventing building or breaking outside arena borders. */
+public final class BorderBuildListener implements Listener {
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService ctx;
+  private final BorderService border;
+
+  public BorderBuildListener(BedwarsPlugin plugin, PlayerContextService ctx, BorderService border) {
+    this.plugin = plugin; this.ctx = ctx; this.border = border;
+  }
+
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  public void onPlace(BlockPlaceEvent e) {
+    Player p = e.getPlayer();
+    String arenaId = ctx.getArena(p);
+    if (arenaId == null) return;
+    Arena a = plugin.arenas().get(arenaId).orElse(null);
+    if (a == null) return;
+    BorderService.Settings b = border.cfg(a);
+    if (!b.enabled) return;
+    Location l = e.getBlockPlaced().getLocation();
+    Vector2D c = border.centerFor(a);
+    if ((b.clampY && (l.getY() < b.minY || l.getY() > b.maxY))
+        || BorderMath.outside2D(l, c.x(), c.z(), b.radius)) {
+      e.setCancelled(true);
+      plugin.messages().send(p, "border.build_block_outside_message");
+    }
+  }
+
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  public void onBreak(BlockBreakEvent e) {
+    Player p = e.getPlayer();
+    String arenaId = ctx.getArena(p);
+    if (arenaId == null) return;
+    Arena a = plugin.arenas().get(arenaId).orElse(null);
+    if (a == null) return;
+    BorderService.Settings b = border.cfg(a);
+    if (!b.enabled) return;
+    Location l = e.getBlock().getLocation();
+    Vector2D c = border.centerFor(a);
+    if (BorderMath.outside2D(l, c.x(), c.z(), b.radius)) {
+      e.setCancelled(true);
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/border/BorderMath.java
+++ b/src/main/java/com/example/bedwars/border/BorderMath.java
@@ -1,0 +1,25 @@
+package com.example.bedwars.border;
+
+import org.bukkit.Location;
+
+/** Geometry helpers for border calculations. */
+public final class BorderMath {
+  private BorderMath() {}
+
+  /** Returns whether the point is outside a circle. */
+  public static boolean outside2D(Location loc, double cx, double cz, double radius) {
+    double dx = loc.getX() - cx;
+    double dz = loc.getZ() - cz;
+    return (dx * dx + dz * dz) > radius * radius;
+  }
+
+  /** Clamp the location inside the circle on the X/Z plane. */
+  public static Location clampInside(Location to, double cx, double cz, double radius) {
+    double dx = to.getX() - cx;
+    double dz = to.getZ() - cz;
+    double dist = Math.sqrt(dx * dx + dz * dz);
+    if (dist <= radius) return to;
+    double k = radius / dist;
+    return new Location(to.getWorld(), cx + dx * k, to.getY(), cz + dz * k, to.getYaw(), to.getPitch());
+  }
+}

--- a/src/main/java/com/example/bedwars/border/BorderMoveListener.java
+++ b/src/main/java/com/example/bedwars/border/BorderMoveListener.java
@@ -1,0 +1,73 @@
+package com.example.bedwars.border;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.game.PlayerContextService;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.util.Vector;
+
+/** Listener handling player movement relative to arena borders. */
+public final class BorderMoveListener implements Listener {
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService ctx;
+  private final BorderService border;
+
+  public BorderMoveListener(BedwarsPlugin plugin, PlayerContextService ctx, BorderService border) {
+    this.plugin = plugin; this.ctx = ctx; this.border = border;
+  }
+
+  @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+  public void onMove(PlayerMoveEvent e) {
+    Player p = e.getPlayer();
+    String arenaId = ctx.getArena(p);
+    if (arenaId == null) return;
+    Arena a = plugin.arenas().get(arenaId).orElse(null);
+    if (a == null) return;
+    BorderService.Settings b = border.cfg(a);
+    if (!b.enabled) return;
+    Location to = e.getTo();
+    if (to == null) return;
+
+    // Clamp vertical
+    if (b.clampY && (to.getY() < b.minY || to.getY() > b.maxY)) {
+      double clampedY = Math.max(b.minY, Math.min(b.maxY, to.getY()));
+      Location tp = to.clone();
+      tp.setY(clampedY);
+      p.teleport(tp, PlayerTeleportEvent.TeleportCause.PLUGIN);
+      plugin.messages().send(p, "border.move_outside_message");
+      return;
+    }
+
+    Vector2D c = border.centerFor(a);
+    double r = b.radius;
+    if (BorderMath.outside2D(to, c.x(), c.z(), r)) {
+      switch (b.onCross) {
+        case PUSH_BACK -> {
+          e.setCancelled(true);
+          Vector push = new Vector(c.x() - to.getX(), 0, c.z() - to.getZ())
+              .normalize().multiply(b.pushStrength);
+          p.setVelocity(push);
+        }
+        case TELEPORT -> {
+          Location tp = BorderMath.clampInside(to, c.x(), c.z(), r);
+          p.teleport(tp, PlayerTeleportEvent.TeleportCause.PLUGIN);
+        }
+        default -> e.setCancelled(true);
+      }
+      plugin.messages().send(p, "border.move_outside_message");
+      return;
+    }
+
+    // Near-border warning
+    double dist = Math.hypot(to.getX() - c.x(), to.getZ() - c.z());
+    if (r - dist <= b.warning) {
+      plugin.actionBar().push(p, plugin.messages().msg("border.move_outside_message"), 1);
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/border/BorderService.java
+++ b/src/main/java/com/example/bedwars/border/BorderService.java
@@ -1,0 +1,137 @@
+package com.example.bedwars.border;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import com.example.bedwars.arena.TeamColor;
+import java.io.File;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.WorldBorder;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+/** Service providing border configuration and world border application per arena. */
+public final class BorderService {
+
+  /** Action to take when a player crosses the border. */
+  public enum Action { PUSH_BACK, TELEPORT, CANCEL }
+
+  /** Border settings for an arena. */
+  public static final class Settings {
+    boolean enabled = true;
+    double radius = 160;
+    Double centerX; // null means auto
+    Double centerZ;
+    int warning = 6;
+    boolean damageEnabled = false;
+    double damageAmount = 0.2;
+    double damageBuffer = 2.0;
+    boolean clampY = true;
+    double minY = 1.0;
+    double maxY = 128.0;
+    Action onCross = Action.PUSH_BACK;
+    double pushStrength = 0.8;
+  }
+
+  private final BedwarsPlugin plugin;
+  private final Map<String, Settings> cache = new ConcurrentHashMap<>();
+  private final Map<String, Vector2D> centers = new ConcurrentHashMap<>();
+
+  public BorderService(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+  }
+
+  /** Get settings for an arena. */
+  public Settings cfg(Arena a) {
+    return cache.computeIfAbsent(a.id(), id -> load(a));
+  }
+
+  private Settings load(Arena a) {
+    Settings s = new Settings();
+    ConfigurationSection base = plugin.getConfig().getConfigurationSection("border");
+    if (base != null) applySection(s, base);
+    File f = new File(plugin.getDataFolder(), "arenas/" + a.id() + ".yml");
+    if (f.exists()) {
+      YamlConfiguration y = YamlConfiguration.loadConfiguration(f);
+      ConfigurationSection sec = y.getConfigurationSection("border");
+      if (sec != null) applySection(s, sec);
+    }
+    return s;
+  }
+
+  private void applySection(Settings s, ConfigurationSection sec) {
+    s.enabled = sec.getBoolean("enabled", s.enabled);
+    if (sec.isDouble("radius")) s.radius = sec.getDouble("radius");
+    if (sec.isConfigurationSection("center")) {
+      ConfigurationSection c = sec.getConfigurationSection("center");
+      s.centerX = c.getDouble("x");
+      s.centerZ = c.getDouble("z");
+    }
+    s.warning = sec.getInt("warning", s.warning);
+    if (sec.isConfigurationSection("damage")) {
+      ConfigurationSection d = sec.getConfigurationSection("damage");
+      s.damageEnabled = d.getBoolean("enabled", s.damageEnabled);
+      s.damageAmount = d.getDouble("amount", s.damageAmount);
+      s.damageBuffer = d.getDouble("buffer", s.damageBuffer);
+    }
+    if (sec.isConfigurationSection("clamp_y")) {
+      ConfigurationSection c = sec.getConfigurationSection("clamp_y");
+      s.clampY = c.getBoolean("enabled", s.clampY);
+      s.minY = c.getDouble("min", s.minY);
+      s.maxY = c.getDouble("max", s.maxY);
+    }
+    if (sec.isConfigurationSection("actions")) {
+      ConfigurationSection c = sec.getConfigurationSection("actions");
+      String act = c.getString("on_cross", s.onCross.name());
+      try { s.onCross = Action.valueOf(act); } catch (IllegalArgumentException ignored) {}
+      s.pushStrength = c.getDouble("push_back_strength", s.pushStrength);
+    }
+  }
+
+  /** Compute center for arena using config or team spawns. */
+  public Vector2D centerFor(Arena a) {
+    return centers.computeIfAbsent(a.id(), id -> {
+      Settings s = cfg(a);
+      if (s.centerX != null && s.centerZ != null) {
+        return new Vector2D(s.centerX, s.centerZ);
+      }
+      // Average team spawns of active teams
+      double sumX = 0, sumZ = 0; int count = 0;
+      for (TeamColor c : EnumSet.copyOf(a.activeTeams())) {
+        Location l = a.team(c).spawn();
+        if (l != null) { sumX += l.getX(); sumZ += l.getZ(); count++; }
+      }
+      if (count == 0) return new Vector2D(0.0, 0.0);
+      return new Vector2D(sumX / count, sumZ / count);
+    });
+  }
+
+  /** Apply world border to arena world. */
+  public void apply(Arena a) {
+    Settings s = cfg(a);
+    if (!s.enabled) return;
+    World w = Bukkit.getWorld(a.world().name());
+    if (w == null) return;
+    WorldBorder wb = w.getWorldBorder();
+    Vector2D c = centerFor(a);
+    wb.setCenter(c.x(), c.z());
+    wb.setSize(s.radius * 2.0);
+    wb.setWarningDistance(s.warning);
+    if (s.damageEnabled) {
+      wb.setDamageAmount(s.damageAmount);
+      wb.setDamageBuffer(s.damageBuffer);
+    } else {
+      wb.setDamageAmount(0.0);
+    }
+  }
+
+  /** Clear cached settings for an arena. */
+  public void reload(String arenaId) {
+    cache.remove(arenaId);
+    centers.remove(arenaId);
+  }
+}

--- a/src/main/java/com/example/bedwars/border/BorderStateListener.java
+++ b/src/main/java/com/example/bedwars/border/BorderStateListener.java
@@ -1,0 +1,23 @@
+package com.example.bedwars.border;
+
+import com.example.bedwars.arena.GameState;
+import com.example.bedwars.game.ArenaStateChangeEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+/** Applies world borders on arena state transitions. */
+public final class BorderStateListener implements Listener {
+  private final BorderService border;
+
+  public BorderStateListener(BorderService border) {
+    this.border = border;
+  }
+
+  @EventHandler
+  public void onStateChange(ArenaStateChangeEvent event) {
+    GameState ns = event.newState();
+    if (ns == GameState.WAITING || ns == GameState.RUNNING) {
+      border.apply(event.arena());
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/border/Vector2D.java
+++ b/src/main/java/com/example/bedwars/border/Vector2D.java
@@ -1,0 +1,4 @@
+package com.example.bedwars.border;
+
+/** Simple 2D vector record. */
+public record Vector2D(double x, double z) {}

--- a/src/main/java/com/example/bedwars/game/GameService.java
+++ b/src/main/java/com/example/bedwars/game/GameService.java
@@ -266,6 +266,7 @@ public final class GameService {
         target.setState(GameState.WAITING);
         plugin.lighting().applyDayClear(target);
         plugin.lighting().relightArena(target);
+        plugin.border().apply(target);
         plugin.messages().broadcast(a, "reset.done");
         plugin.npcs().ensureSpawned(target);
       }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -152,6 +152,23 @@ scoreboard:
 actionbar:
   enabled: true
 
+border:
+  enabled: true
+  center: { x: 0.5, z: 0.5 }
+  radius: 160
+  warning: 6
+  damage:
+    enabled: false
+    amount: 0.2
+    buffer: 2.0
+  clamp_y:
+    enabled: true
+    min: 1
+    max: 128
+  actions:
+    on_cross: "PUSH_BACK"
+    push_back_strength: 0.8
+
 reset:
   lobby_world: "world"
   lobby_spawn: { x: 0, y: 100, z: 0, yaw: 0, pitch: 0 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -158,6 +158,10 @@ gens:
   diamond_t3: "&bDiamant III &7→ Vitesse maximale diamant !"
   emerald_t2: "&aÉmeraude II &7→ Générateurs émeraude accélérés !"
   emerald_t3: "&aÉmeraude III &7→ Vitesse maximale émeraude !"
+
+border:
+  build_block_outside_message: "&cHors limites de l'arène."
+  move_outside_message: "&cRetourne dans la zone de jeu !"
   cap_reached: "&7Cap atteint: &f{type} &7({count}/{cap}). Videz le pad !"
 
 upgrades:


### PR DESCRIPTION
## Summary
- enforce per-arena world borders with configurable center, radius and Y clamps
- block movement and building outside arena bounds
- wire service into game lifecycle to apply border after resets

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*


------
https://chatgpt.com/codex/tasks/task_e_689d93ac67f8832985184392ffa6fc4d