### PR TITLE
Improve countdown, borders and lobby items

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -156,7 +156,7 @@ public final class BedwarsPlugin extends JavaPlugin {
     getServer().getPluginManager().registerEvents(new LobbyListener(this, lobbyItems, teamSelectMenu, contextService, gameService), this);
     getServer().getPluginManager().registerEvents(new CompassListener(this, contextService, teamSelectMenu), this);
     getServer().getPluginManager().registerEvents(new ArmorLockListener(this, contextService), this);
-    getServer().getPluginManager().registerEvents(new GameplayListener(this, contextService), this);
+    getServer().getPluginManager().registerEvents(new GameplayListener(this, contextService, lobbyItems), this);
     getServer().getPluginManager().registerEvents(new FireballListener(this, contextService), this);
     getServer().getPluginManager().registerEvents(new BorderMoveListener(this, contextService, borderService), this);
     getServer().getPluginManager().registerEvents(new BorderBuildListener(this, contextService, borderService), this);

--- a/src/main/java/com/example/bedwars/border/BorderService.java
+++ b/src/main/java/com/example/bedwars/border/BorderService.java
@@ -23,7 +23,7 @@ public final class BorderService {
   /** Border settings for an arena. */
   public static final class Settings {
     boolean enabled = true;
-    double radius = 160;
+    double radius = 120;
     Double centerX; // null means auto
     Double centerZ;
     int warning = 6;

--- a/src/main/java/com/example/bedwars/game/CountdownAnnouncer.java
+++ b/src/main/java/com/example/bedwars/game/CountdownAnnouncer.java
@@ -1,0 +1,32 @@
+package com.example.bedwars.game;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.bukkit.entity.Player;
+
+/** Announces countdown messages without spamming chat. */
+public final class CountdownAnnouncer {
+  private final BedwarsPlugin plugin;
+  private final Set<Integer> milestones;
+  private final boolean actionbarEnabled;
+
+  public CountdownAnnouncer(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+    this.milestones = new TreeSet<>(plugin.getConfig().getIntegerList("countdown.chat_milestones"));
+    this.actionbarEnabled = plugin.getConfig().getBoolean("countdown.actionbar_enabled", true);
+  }
+
+  public void tick(Arena arena, int secondsLeft) {
+    if (milestones.contains(secondsLeft)) {
+      plugin.messages().broadcast(arena, "countdown.chat", Map.of("sec", secondsLeft));
+    } else if (actionbarEnabled) {
+      String ab = plugin.messages().format("actionbar.countdown", Map.of("sec", secondsLeft));
+      for (Player p : plugin.contexts().playersInArena(arena.id())) {
+        plugin.actionBar().push(p, ab, 1);
+      }
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/game/GameService.java
+++ b/src/main/java/com/example/bedwars/game/GameService.java
@@ -29,6 +29,7 @@ public final class GameService {
   private final GameMessages messages;
   private final com.example.bedwars.lobby.LobbyItemsService lobbyItems;
   private DeathRespawnService deathService;
+  private final CountdownAnnouncer countdownAnnouncer;
   private final Map<String, Integer> countdownTasks = new HashMap<>();
   private final Map<String, Integer> timerTasks = new HashMap<>();
   private final Map<String, Integer> gameTime = new HashMap<>();
@@ -43,6 +44,7 @@ public final class GameService {
     this.spectator = spec;
     this.messages = msgs;
     this.lobbyItems = lobbyItems;
+    this.countdownAnnouncer = new CountdownAnnouncer(plugin);
   }
 
   public void setDeathService(DeathRespawnService drs) { this.deathService = drs; }
@@ -151,11 +153,7 @@ public final class GameService {
       @Override public void run() {
         if (a.state() != GameState.STARTING) { cancel(); return; }
         if (sec <= 0) { cancel(); beginRunning(a); return; }
-        messages.broadcast(a, "game.starting-in", Map.of("sec", sec));
-        String ab = plugin.messages().format("actionbar.starting_in", Map.of("sec", sec));
-        for (Player p : contexts.playersInArena(a.id())) {
-          plugin.actionBar().push(p, ab, 1);
-        }
+        countdownAnnouncer.tick(a, sec);
         sec--;
       }
     }.runTaskTimer(plugin, 0L, 20L).getTaskId();

--- a/src/main/java/com/example/bedwars/gui/TeamSelectMenu.java
+++ b/src/main/java/com/example/bedwars/gui/TeamSelectMenu.java
@@ -3,7 +3,6 @@ package com.example.bedwars.gui;
 import com.example.bedwars.BedwarsPlugin;
 import com.example.bedwars.arena.Arena;
 import com.example.bedwars.arena.TeamColor;
-import com.example.bedwars.arena.TeamData;
 import com.example.bedwars.game.PlayerContextService;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,16 +29,11 @@ public final class TeamSelectMenu implements Listener {
   /** Opens the team selection menu for a player and arena. */
   public void open(Player p, Arena a) {
     if (a == null) return;
-    Inventory inv = Bukkit.createInventory(null, 9, plugin.messages().get("game.choose-team-title"));
+    Inventory inv = Bukkit.createInventory(null, 9, plugin.messages().get("menu.team_selector_title"));
     int i = 0;
     for (TeamColor tc : a.activeTeams()) {
       int count = ctx.countPlayers(a.id(), tc);
-      ItemStack icon;
-      if (count >= a.maxTeamSize()) {
-        icon = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
-      } else {
-        icon = new ItemStack(tc.wool);
-      }
+      ItemStack icon = count >= a.maxTeamSize() ? new ItemStack(Material.GRAY_STAINED_GLASS_PANE) : new ItemStack(tc.wool);
       ItemMeta meta = icon.getItemMeta();
       if (meta != null) {
         meta.setDisplayName(tc.color + tc.display);
@@ -56,7 +50,7 @@ public final class TeamSelectMenu implements Listener {
   @EventHandler(ignoreCancelled = true)
   public void onClick(InventoryClickEvent e) {
     if (!(e.getWhoClicked() instanceof Player p)) return;
-    if (!plugin.messages().get("game.choose-team-title").equals(e.getView().getTitle())) return;
+    if (!plugin.messages().get("menu.team_selector_title").equals(e.getView().getTitle())) return;
     e.setCancelled(true);
     ItemStack clicked = e.getCurrentItem();
     if (clicked == null) return;
@@ -68,12 +62,11 @@ public final class TeamSelectMenu implements Listener {
       if (clicked.getType() == tc.wool) {
         int count = ctx.countPlayers(arenaId, tc);
         if (count >= a.maxTeamSize()) {
-          p.sendMessage(plugin.messages().format("errors.team_full", java.util.Map.of("count", count, "max", a.maxTeamSize())));
+          plugin.messages().send(p, "errors.team_full", java.util.Map.of());
           return;
         }
         ctx.setTeam(p, tc);
-        p.sendMessage(plugin.messages().get("prefix") +
-            plugin.messages().format("team.chosen", java.util.Map.of("team", tc.display)));
+        plugin.messages().send(p, "menu.team_joined", java.util.Map.of("team", tc.display));
         p.closeInventory();
         return;
       }

--- a/src/main/java/com/example/bedwars/hud/ScoreboardManager.java
+++ b/src/main/java/com/example/bedwars/hud/ScoreboardManager.java
@@ -93,11 +93,18 @@ public final class ScoreboardManager {
     }
     set(sb, i++, "  ");
     int dTier = plugin.generators().diamondTier(a.id());
-    int dSec = plugin.generators().nextDiamondDropSeconds(a.id());
     int eTier = plugin.generators().emeraldTier(a.id());
-    int eSec = plugin.generators().nextEmeraldDropSeconds(a.id());
-    set(sb, i++, color(msg("scoreboard.diamond_line").replace("{tier}", roman(dTier)).replace("{sec}", String.valueOf(dSec))));
-    set(sb, i++, color(msg("scoreboard.emerald_line").replace("{tier}", roman(eTier)).replace("{sec}", String.valueOf(eSec))));
+    boolean showDrop = plugin.getConfig().getBoolean("scoreboard.show_next_drop", false);
+    boolean tiersOnly = plugin.getConfig().getBoolean("scoreboard.show_tiers_only", false);
+    if (showDrop && !tiersOnly) {
+      int dSec = plugin.generators().nextDiamondDropSeconds(a.id());
+      int eSec = plugin.generators().nextEmeraldDropSeconds(a.id());
+      set(sb, i++, color(msg("scoreboard.diamond_drop_line").replace("{tier}", roman(dTier)).replace("{sec}", String.valueOf(dSec))));
+      set(sb, i++, color(msg("scoreboard.emerald_drop_line").replace("{tier}", roman(eTier)).replace("{sec}", String.valueOf(eSec))));
+    } else {
+      set(sb, i++, color(msg("scoreboard.diamond_line").replace("{tier}", roman(dTier))));
+      set(sb, i++, color(msg("scoreboard.emerald_line").replace("{tier}", roman(eTier))));
+    }
     set(sb, i++, "   ");
     set(sb, i++, color("&7" + plugin.messages().get("brand.line")));
     while (i < KEYS.length) set(sb, i++, "");

--- a/src/main/java/com/example/bedwars/listeners/GameplayListener.java
+++ b/src/main/java/com/example/bedwars/listeners/GameplayListener.java
@@ -2,6 +2,7 @@ package com.example.bedwars.listeners;
 
 import com.example.bedwars.BedwarsPlugin;
 import com.example.bedwars.game.PlayerContextService;
+import com.example.bedwars.lobby.LobbyItemsService;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -16,14 +17,24 @@ import org.bukkit.inventory.ItemStack;
 public final class GameplayListener implements Listener {
   private final BedwarsPlugin plugin;
   private final PlayerContextService ctx;
+  private final LobbyItemsService items;
 
-  public GameplayListener(BedwarsPlugin plugin, PlayerContextService ctx) {
+  public GameplayListener(BedwarsPlugin plugin, PlayerContextService ctx, LobbyItemsService items) {
     this.plugin = plugin;
     this.ctx = ctx;
+    this.items = items;
   }
 
   private boolean noDropSwords() {
-    return plugin.getConfig().getBoolean("gameplay.no_drop_swords", true);
+    return plugin.getConfig().getBoolean("anti_drop.swords", true);
+  }
+
+  private boolean noDropSelector() {
+    return plugin.getConfig().getBoolean("anti_drop.selector_item", true);
+  }
+
+  private boolean noDropLeave() {
+    return plugin.getConfig().getBoolean("anti_drop.leave_item", true);
   }
 
   private boolean noHunger() {
@@ -36,25 +47,35 @@ public final class GameplayListener implements Listener {
 
   @EventHandler(ignoreCancelled = true)
   public void onDrop(PlayerDropItemEvent e) {
-    if (!noDropSwords()) return;
     Player p = e.getPlayer();
     if (ctx.getArena(p) == null) return;
-    if (isSword(e.getItemDrop().getItemStack().getType())) {
+    ItemStack drop = e.getItemDrop().getItemStack();
+    Material m = drop.getType();
+    if (noDropSwords() && isSword(m)) {
       e.setCancelled(true);
       plugin.messages().send(p, "errors.cannot_drop_sword");
+      return;
+    }
+    if ((noDropSelector() && items.isTeamSelector(drop)) || (noDropLeave() && items.isLeaveItem(drop))) {
+      e.setCancelled(true);
     }
   }
 
   @EventHandler(ignoreCancelled = true)
   public void onInvClick(InventoryClickEvent e) {
-    if (!noDropSwords()) return;
     if (!(e.getWhoClicked() instanceof Player p)) return;
     if (ctx.getArena(p) == null) return;
     if (e.getClick() == ClickType.DROP || e.getClick() == ClickType.CONTROL_DROP) {
       ItemStack cur = e.getCurrentItem();
-      if (cur != null && isSword(cur.getType())) {
+      if (cur == null) return;
+      Material m = cur.getType();
+      if (noDropSwords() && isSword(m)) {
         e.setCancelled(true);
         plugin.messages().send(p, "errors.cannot_drop_sword");
+        return;
+      }
+      if ((noDropSelector() && items.isTeamSelector(cur)) || (noDropLeave() && items.isLeaveItem(cur))) {
+        e.setCancelled(true);
       }
     }
   }

--- a/src/main/java/com/example/bedwars/lobby/LobbyItemsService.java
+++ b/src/main/java/com/example/bedwars/lobby/LobbyItemsService.java
@@ -11,12 +11,16 @@ import org.bukkit.inventory.meta.ItemMeta;
 public final class LobbyItemsService {
   private final BedwarsPlugin plugin;
   private final ItemStack teamSelector;
+  private final int teamSelectorSlot;
   private final ItemStack leaveItem;
+  private final int leaveItemSlot;
 
   public LobbyItemsService(BedwarsPlugin plugin) {
     this.plugin = plugin;
-    this.teamSelector = createItem("lobby.team_selector");
-    this.leaveItem = createItem("lobby.leave_item");
+    this.teamSelector = createItem("items.team_selector");
+    this.teamSelectorSlot = plugin.getConfig().getInt("items.team_selector.slot", 0);
+    this.leaveItem = createItem("items.leave_arena");
+    this.leaveItemSlot = plugin.getConfig().getInt("items.leave_arena.slot", 8);
   }
 
   private ItemStack createItem(String path) {
@@ -33,8 +37,8 @@ public final class LobbyItemsService {
 
   public void giveLobbyItems(Player p) {
     p.getInventory().clear();
-    p.getInventory().setItem(0, teamSelector.clone());
-    p.getInventory().setItem(8, leaveItem.clone());
+    p.getInventory().setItem(teamSelectorSlot, teamSelector.clone());
+    p.getInventory().setItem(leaveItemSlot, leaveItem.clone());
   }
 
   public boolean isTeamSelector(ItemStack it) {
@@ -44,4 +48,7 @@ public final class LobbyItemsService {
   public boolean isLeaveItem(ItemStack it) {
     return it != null && it.isSimilar(leaveItem);
   }
+
+  public ItemStack teamSelectorItem() { return teamSelector; }
+  public ItemStack leaveItem() { return leaveItem; }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,17 +29,21 @@ generators:
   split_generator: true
   auto_collect_radius: 1.2
   spawn_offset_y: 0.5
+  diamond:
+    tier2_at_seconds: 360
+    tier3_at_seconds: 660
+  emerald:
+    tier2_at_seconds: 420
+    tier3_at_seconds: 720
 global_tiers:
   diamond:
     tier1_interval_ticks: 600
     tier2_interval_ticks: 400
     tier3_interval_ticks: 300
-    announce_times_sec: [300, 540]
   emerald:
     tier1_interval_ticks: 1300
     tier2_interval_ticks: 1000
     tier3_interval_ticks: 640
-    announce_times_sec: [420, 780]
 entity_caps:
   team_iron: 48
   team_gold: 12
@@ -74,6 +78,10 @@ game:
   void-kill-y: -5
   keep-inventory: false
   auto-assign-on-join: false
+
+countdown:
+  chat_milestones: [20, 10, 5, 4, 3, 2, 1]
+  actionbar_enabled: true
 rules:
   protect-lobby: true
   friendly-fire: false
@@ -127,8 +135,12 @@ tnt:
 
 gameplay:
   lock_armor: true
-  no_drop_swords: true
   no_hunger: true
+
+anti_drop:
+  swords: true
+  leave_item: true
+  selector_item: true
 
 fireball:
   enabled: true
@@ -139,23 +151,27 @@ fireball:
   break_only_player_blocks: true
   cooldown_ticks: 20
 
-lobby:
+items:
   team_selector:
-    material: COMPASS
-    name: "&aSélecteur d'équipe"
-  leave_item:
-    material: BARRIER
-    name: "&cQuitter l'arène"
+    material: NETHER_STAR
+    name: "&bSélecteur d’équipe"
+    slot: 0
+  leave_arena:
+    material: OAK_DOOR
+    name: "&cQuitter l’arène"
+    slot: 8
 
 scoreboard:
   enabled: true
+  show_next_drop: false
+  show_tiers_only: true
 actionbar:
   enabled: true
 
 border:
   enabled: true
   center: { x: 0.5, z: 0.5 }
-  radius: 160
+  radius: 120
   warning: 6
   damage:
     enabled: false

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -3,7 +3,7 @@ prefix: "&6[BedWars]&r "
 errors:
   no_perm: "&cTu n'as pas la permission."
   arena_unknown: "&cArène inconnue: &f{arena}"
-  team_full: "&cCette équipe est pleine (&f{count}/{max}&c)."
+  team_full: "&cCette équipe est pleine."
   not_running: "&cAction impossible hors partie."
   not_allowed_block: "&cBloc non autorisé."
   map_protected: "&cCarte protégée."
@@ -14,24 +14,33 @@ errors:
   cannot_remove_armor: "&cTu ne peux pas enlever ton armure."
   cannot_drop_sword: "&cTu ne peux pas jeter ton épée."
 
+countdown:
+  chat: "&eLa partie démarre dans &6{sec}s"
+
 menu:
   title_admin: "&eMenu Admin"
   team_mode_title: "&eMode d'équipes"
   running_locked: "&cAction impossible pendant une partie."
+  team_selector_title: "&bChoisis ton équipe"
+  team_disabled: "&8[hors service]"
+  team_joined: "&aTu as rejoint &f{team}"
 
 player:
   joined_arena: "&aTu as rejoint &f{arena}&a."
-  left_arena: "&eTu as quitté &f{arena}&e."
+  left_arena: "&eTu as quitté l’arène."
 
 scoreboard:
   title: "&e&lBEDWARS"
   bed_ok: "✔"
   bed_broken: "✖"
-  diamond_line: "&bDiamant: &fTier {tier} &7t-{sec}s"
-  emerald_line: "&aÉmeraude: &fTier {tier} &7t-{sec}s"
+  diamond_line: "&bDiamant: &fTier {tier}"
+  emerald_line: "&aÉmeraude: &fTier {tier}"
+  diamond_drop_line: "&bDiamant: &fTier {tier} &7t-{sec}s"
+  emerald_drop_line: "&aÉmeraude: &fTier {tier} &7t-{sec}s"
 
 actionbar:
   starting_in: "&eDépart dans &6{sec}s"
+  countdown: "&7Départ dans &f{sec}s"
   trap_triggered: "&cPiège déclenché !"
   bed_broken: "&eLit de &f{team}&e détruit !"
   tier_up: "&b{res} Tier {tier} atteint"


### PR DESCRIPTION
## Summary
- add configurable countdown announcer with actionbar support
- shorten world border radius and make scoreboard show only resource tiers
- replace lobby items with nether star team selector and oak door quit item with anti-drop

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d998681d483298127d6d038ee0b77