### PR TITLE
Add backup admin command stub

### DIFF
--- a/src/main/java/com/example/bedwars/command/BwAdminCommand.java
+++ b/src/main/java/com/example/bedwars/command/BwAdminCommand.java
@@ -65,6 +65,20 @@ public final class BwAdminCommand implements CommandExecutor {
       return true;
     }
 
+    if (args[0].equalsIgnoreCase("backup")) {
+      if (!sender.hasPermission("bedwars.admin.backup")) {
+        sender.sendMessage(plugin.messages().get("errors.no_perm"));
+        return true;
+      }
+      if (args.length >= 2 && args[1].equalsIgnoreCase("now")) {
+        sender.sendMessage(
+            plugin.messages().get("prefix") + plugin.messages().get("backup.not_implemented"));
+      } else {
+        sender.sendMessage(plugin.messages().get("prefix") + "Usage: /bwadmin backup now");
+      }
+      return true;
+    }
+
     if (args[0].equalsIgnoreCase("debug")) {
       handleDebug(sender, args);
       return true;

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -62,6 +62,7 @@ help.admin:
   - "&7/bwadmin arena save <id> &f- sauvegarde une arene"
   - "&7/bwadmin arena reload <id> &f- recharge une arene"
   - "&7/bwadmin arena delete <id> &f- supprime une arene"
+  - "&7/bwadmin backup now &f- backup immédiat (WIP)"
 
 generic.reloaded: "&aConfiguration rechargée."
 arena.created: "&aArène %s créée."
@@ -197,6 +198,9 @@ reset:
   done: "&aReset terminé. Retour en &fWAITING"
   failed: "&cÉchec du reset: &f{error}"
   restoring_at_start: "&7Restauration des mondes d'arène au démarrage..."
+
+backup:
+  not_implemented: "&cBackup non implémenté."
 forcestart:
   countdown: "&eLa partie démarre dans &6{sec}s"
   started: "&aLa partie commence !"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,6 +26,7 @@ permissions:
       bedwars.admin.reset: true
       bedwars.admin.debug: true
       bedwars.admin.maintenance: true
+      bedwars.admin.backup: true
   bedwars.menu.rules:
     description: Ouvrir le menu Règles via la boussole
     default: true


### PR DESCRIPTION
## Summary
- add `/bwadmin backup now` admin subcommand that replies with a placeholder message
- introduce backup message key and help entry
- declare `bedwars.admin.backup` permission

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d9da193f88329a883fb70e5f449ee