### PR TITLE
feat: add gui border helper

### DIFF
--- a/src/main/java/com/example/bedwars/gui/GuiFactory.java
+++ b/src/main/java/com/example/bedwars/gui/GuiFactory.java
@@ -1,0 +1,35 @@
+package com.example.bedwars.gui;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/** Utility methods for building GUI inventories. */
+public final class GuiFactory {
+  private GuiFactory() {}
+
+  /**
+   * Fills the outer border of the inventory with the given material.
+   * The panes are named with a single space so they appear blank.
+   */
+  public static void fillBorder(Inventory inv, Material mat) {
+    int size = inv.getSize();
+    if (size % 9 != 0) return; // only grids
+    ItemStack pane = new ItemStack(mat);
+    ItemMeta meta = pane.getItemMeta();
+    if (meta != null) {
+      meta.setDisplayName(" ");
+      pane.setItemMeta(meta);
+    }
+    int rows = size / 9;
+    for (int r = 0; r < rows; r++) {
+      for (int c = 0; c < 9; c++) {
+        if (r == 0 || r == rows - 1 || c == 0 || c == 8) {
+          int slot = r * 9 + c;
+          inv.setItem(slot, pane);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/example/bedwars/shop/ItemShopMenu.java
+++ b/src/main/java/com/example/bedwars/shop/ItemShopMenu.java
@@ -36,9 +36,10 @@ public final class ItemShopMenu {
   public void open(Player p, String arenaId, TeamColor team, ShopCategory cat) {
     String title = plugin.messages().format("shop.title", Map.of("cat", cat.name()));
     Inventory inv = Bukkit.createInventory(new Holder(arenaId, team, cat), 54, title);
+    com.example.bedwars.gui.GuiFactory.fillBorder(inv, Material.GRAY_STAINED_GLASS_PANE);
 
-    // categories bar
-    int i = 0;
+    // categories bar starts at slot 1 leaving border panes at 0 and 8
+    int i = 1;
     for (ShopCategory c : ShopCategory.values()) {
       ItemStack it = new ItemStack(ICONS.getOrDefault(c, Material.BARRIER));
       ItemMeta im = it.getItemMeta();

--- a/src/main/java/com/example/bedwars/shop/ShopListener.java
+++ b/src/main/java/com/example/bedwars/shop/ShopListener.java
@@ -80,9 +80,11 @@ public final class ShopListener implements Listener {
       if (!(e.getWhoClicked() instanceof Player p)) return;
       int slot = e.getRawSlot();
       if (slot < 9) {
+        if (slot == 0 || slot == 8) return; // border panes
         ShopCategory[] cats = ShopCategory.values();
-        if (slot >= cats.length) return;
-        itemMenu.open(p, ih.arenaId, ih.team, cats[slot]);
+        int idx = slot - 1;
+        if (idx < 0 || idx >= cats.length) return;
+        itemMenu.open(p, ih.arenaId, ih.team, cats[idx]);
         return;
       }
       int index = slot - 9;


### PR DESCRIPTION
## Summary
- add GuiFactory utility to draw borders around GUIs
- use GuiFactory in item shop and adjust category slots
- account for border clicks in shop listener

## Testing
- `mvn -q test` *(fails: PluginResolutionException: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689db6f7e9e4832983c13047c5c99804