### PR TITLE
Add progressive pickaxe upgrades with persistence

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -81,6 +81,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   private ResetManager resetManager;
   private TasksService tasksService;
   private BorderService borderService;
+  private com.example.bedwars.services.ToolsService toolsService;
 
   @Override
   public void onEnable() {
@@ -124,6 +125,7 @@ public final class BedwarsPlugin extends JavaPlugin {
       this.npcManager.ensureSpawned(a);
     }
     this.tasksService = new TasksService(this);
+    this.toolsService = new com.example.bedwars.services.ToolsService(this);
 
     this.actionBarBus = new com.example.bedwars.hud.ActionBarBus();
     if (getConfig().getBoolean("actionbar.enabled", true)) {
@@ -161,6 +163,7 @@ public final class BedwarsPlugin extends JavaPlugin {
     getServer().getPluginManager().registerEvents(new BorderMoveListener(this, contextService, borderService), this);
     getServer().getPluginManager().registerEvents(new BorderBuildListener(this, contextService, borderService), this);
     getServer().getPluginManager().registerEvents(new BorderStateListener(borderService), this);
+    getServer().getPluginManager().registerEvents(new com.example.bedwars.listeners.ToolsListener(toolsService), this);
 
     getLogger().info("Bedwars loaded.");
   }
@@ -221,4 +224,5 @@ public final class BedwarsPlugin extends JavaPlugin {
   public ResetManager reset() { return resetManager; }
   public TasksService tasks() { return tasksService; }
   public BorderService border() { return borderService; }
+  public com.example.bedwars.services.ToolsService tools() { return toolsService; }
 }

--- a/src/main/java/com/example/bedwars/listeners/ToolsListener.java
+++ b/src/main/java/com/example/bedwars/listeners/ToolsListener.java
@@ -1,0 +1,39 @@
+package com.example.bedwars.listeners;
+
+import com.example.bedwars.services.ToolsService;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Hooks player lifecycle events for tool persistence and rules.
+ */
+public final class ToolsListener implements Listener {
+  private final ToolsService tools;
+  public ToolsListener(ToolsService tools) { this.tools = tools; }
+
+  @EventHandler
+  public void onJoin(PlayerJoinEvent e) { tools.load(e.getPlayer()); }
+
+  @EventHandler
+  public void onQuit(PlayerQuitEvent e) { tools.save(e.getPlayer()); }
+
+  @EventHandler
+  public void onRespawn(PlayerRespawnEvent e) { tools.onRespawn(e.getPlayer()); }
+
+  @EventHandler
+  public void onDeath(PlayerDeathEvent e) { tools.onDeath(e.getEntity(), e.getDrops()); }
+
+  @EventHandler(ignoreCancelled = true)
+  public void onDrop(PlayerDropItemEvent e) {
+    Player p = e.getPlayer();
+    ItemStack it = e.getItemDrop().getItemStack();
+    if (!tools.canDrop(p, it)) e.setCancelled(true);
+  }
+}

--- a/src/main/java/com/example/bedwars/services/ToolsService.java
+++ b/src/main/java/com/example/bedwars/services/ToolsService.java
@@ -1,0 +1,218 @@
+package com.example.bedwars.services;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.shop.Currency;
+import com.example.bedwars.shop.PurchaseService;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Manages permanent tool tiers for players (pickaxe progression).
+ */
+public final class ToolsService {
+  public enum PickTier { T0, T1, T2, T3, T4 }
+  public record PickSpec(Material mat, int eff, Currency cur, int cost, PickTier requires) {}
+
+  private final BedwarsPlugin plugin;
+  private final Map<PickTier, PickSpec> specs = new EnumMap<>(PickTier.class);
+  private final Map<UUID, PlayerData> data = new HashMap<>();
+  private final File dataDir;
+  private final boolean requireSequential;
+  private final boolean downgradeOnDeath;
+  private final boolean unbreakable;
+  private final boolean noDrop;
+
+  static final class PlayerData {
+    PickTier pickTier = PickTier.T0;
+    int axeTier = 0;
+    boolean hasShears = false;
+  }
+
+  public ToolsService(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+    ConfigurationSection root = plugin.getConfig().getConfigurationSection("tools.pickaxe");
+    if (root == null) root = plugin.getConfig().createSection("tools.pickaxe");
+    this.requireSequential = root.getBoolean("require_sequential", true);
+    this.downgradeOnDeath = root.getBoolean("downgrade_on_death", false);
+    this.unbreakable = root.getBoolean("unbreakable", true);
+    this.noDrop = root.getBoolean("no_drop", true);
+    ConfigurationSection tiers = root.getConfigurationSection("tiers");
+    if (tiers != null) {
+      for (String k : tiers.getKeys(false)) {
+        int idx;
+        try { idx = Integer.parseInt(k); } catch (Exception ex) { continue; }
+        ConfigurationSection t = tiers.getConfigurationSection(k);
+        if (t == null) continue;
+        Material mat = Material.matchMaterial(t.getString("material", "WOODEN_PICKAXE"));
+        int eff = t.getInt("efficiency", 1);
+        ConfigurationSection priceSec = t.getConfigurationSection("price");
+        Currency cur = Currency.IRON;
+        int cost = 0;
+        if (priceSec != null && !priceSec.getKeys(false).isEmpty()) {
+          String cKey = priceSec.getKeys(false).iterator().next();
+          try { cur = Currency.valueOf(cKey.toUpperCase(Locale.ROOT)); } catch (Exception ignore) {}
+          cost = priceSec.getInt(cKey);
+        }
+        PickTier req = PickTier.T0;
+        int reqI = t.getInt("requires", 0);
+        if (reqI >=0 && reqI < PickTier.values().length) req = PickTier.values()[reqI];
+        specs.put(PickTier.values()[idx], new PickSpec(mat, eff, cur, cost, req));
+      }
+    }
+    this.dataDir = new File(plugin.getDataFolder(), "playerdata");
+    dataDir.mkdirs();
+  }
+
+  private PlayerData data(Player p) {
+    return data.computeIfAbsent(p.getUniqueId(), id -> loadData(id));
+  }
+
+  private PlayerData loadData(UUID id) {
+    PlayerData d = new PlayerData();
+    File f = new File(dataDir, id.toString() + ".json");
+    if (f.exists()) {
+      YamlConfiguration y = YamlConfiguration.loadConfiguration(f);
+      int pt = y.getInt("pickaxeTier", 0);
+      if (pt >=0 && pt < PickTier.values().length) d.pickTier = PickTier.values()[pt];
+      d.axeTier = y.getInt("axeTier", 0);
+      d.hasShears = y.getBoolean("hasShears", false);
+    }
+    return d;
+  }
+
+  private void saveData(UUID id, PlayerData d) {
+    File f = new File(dataDir, id.toString() + ".json");
+    YamlConfiguration y = new YamlConfiguration();
+    y.set("pickaxeTier", d.pickTier.ordinal());
+    y.set("axeTier", d.axeTier);
+    y.set("hasShears", d.hasShears);
+    try { y.save(f); } catch (IOException ex) { plugin.getLogger().warning("Save fail " + ex); }
+  }
+
+  public void load(Player p) { data(p); }
+  public void save(Player p) { PlayerData d = data.get(p.getUniqueId()); if (d != null) saveData(p.getUniqueId(), d); }
+
+  public PickTier next(PickTier cur){ return switch(cur){ case T0->PickTier.T1; case T1->PickTier.T2; case T2->PickTier.T3; case T3->PickTier.T4; default->PickTier.T4; }; }
+
+  private static String displayMat(Material m) {
+    String n = m.name().toLowerCase(Locale.ROOT).replace('_', ' ');
+    return Character.toUpperCase(n.charAt(0)) + n.substring(1);
+  }
+  private static String displayCurrency(Currency c) {
+    return switch (c) {
+      case IRON -> "Fer"; case GOLD -> "Or"; case EMERALD -> "Émeraudes"; case DIAMOND -> "Diamants"; };
+  }
+
+  public ItemStack createPickaxeIcon(Player p) {
+    PlayerData d = data(p);
+    PickTier cur = d.pickTier;
+    PickTier nxt = next(cur);
+    ItemStack it;
+    if (nxt == cur) {
+      it = new ItemStack(Material.EMERALD);
+    } else {
+      PickSpec ns = specs.get(nxt);
+      it = new ItemStack(ns != null ? ns.mat() : Material.WOODEN_PICKAXE);
+    }
+    ItemMeta im = it.getItemMeta();
+    if (im != null) {
+      im.setDisplayName(plugin.messages().get("shop.tools.pickaxe.title"));
+      java.util.List<String> lore = new ArrayList<>();
+      PickSpec cs = specs.get(cur);
+      if (cs != null && cur != PickTier.T0) {
+        lore.add(plugin.messages().format("shop.tools.pickaxe.current", Map.of("mat", displayMat(cs.mat()), "eff", cs.eff())));
+      } else {
+        lore.add(plugin.messages().format("shop.tools.pickaxe.current", Map.of("mat", "Aucune", "eff", 0)));
+      }
+      if (nxt == cur) {
+        lore.add(plugin.messages().get("shop.tools.pickaxe.max"));
+      } else {
+        PickSpec ns = specs.get(nxt);
+        boolean can = PurchaseService.count(p, ns.cur()) >= ns.cost();
+        String price = (can ? ChatColor.GREEN : ChatColor.RED) + String.valueOf(ns.cost()) + " " + displayCurrency(ns.cur());
+        lore.add(plugin.messages().format("shop.tools.pickaxe.next", Map.of("mat", displayMat(ns.mat()), "eff", ns.eff(), "price", price)));
+      }
+      lore.add(plugin.messages().get("shop.tools.pickaxe.permanent"));
+      im.setLore(lore);
+      it.setItemMeta(im);
+    }
+    return it;
+  }
+
+  public boolean buyNextPick(Player p) {
+    PlayerData d = data(p);
+    PickTier cur = d.pickTier;
+    PickTier nxt = next(cur);
+    if (nxt == cur) {
+      p.sendMessage(plugin.messages().get("shop.tools.pickaxe.max"));
+      return false;
+    }
+    PickSpec s = specs.get(nxt);
+    if (requireSequential && s.requires() != cur) {
+      p.sendMessage(plugin.messages().get("errors.pickaxe.seq"));
+      return false;
+    }
+    if (!PurchaseService.tryBuy(p, s.cur(), s.cost())) {
+      plugin.messages().send(p, "shop.need", Map.of("amount", s.cost(), "currency", s.cur().name()));
+      return false;
+    }
+    d.pickTier = nxt;
+    givePick(p, s);
+    plugin.messages().send(p, "shop.tools.pickaxe.bought", Map.of("mat", displayMat(s.mat()), "eff", s.eff()));
+    save(p);
+    return true;
+  }
+
+  public void givePick(Player p) {
+    PlayerData d = data(p);
+    PickSpec s = specs.get(d.pickTier);
+    if (s != null) givePick(p, s);
+  }
+
+  private void givePick(Player p, PickSpec s) {
+    ItemStack it = new ItemStack(s.mat());
+    ItemMeta m = it.getItemMeta();
+    if (m != null) {
+      m.addEnchant(Enchantment.DIG_SPEED, s.eff(), true);
+      if (unbreakable) m.setUnbreakable(true);
+      it.setItemMeta(m);
+    }
+    Inventory inv = p.getInventory();
+    int slot = -1;
+    for (int i = 0; i < inv.getSize(); i++) {
+      ItemStack cur = inv.getItem(i);
+      if (cur != null && cur.getType().name().endsWith("_PICKAXE")) { slot = i; break; }
+    }
+    if (slot >= 0) inv.setItem(slot, it); else inv.addItem(it);
+  }
+
+  public void onRespawn(Player p) { givePick(p); }
+
+  public void onDeath(Player p, java.util.List<ItemStack> drops) {
+    PlayerData d = data(p);
+    if (noDrop) drops.removeIf(is -> is.getType().name().endsWith("_PICKAXE"));
+    if (downgradeOnDeath && d.pickTier.ordinal() > 1) {
+      d.pickTier = PickTier.values()[d.pickTier.ordinal() - 1];
+    }
+  }
+
+  public boolean canDrop(Player p, ItemStack it) {
+    if (!noDrop) return true;
+    if (it.getType().name().endsWith("_PICKAXE")) {
+      PlayerData d = data(p);
+      return d.pickTier == PickTier.T0;
+    }
+    return true;
+  }
+}
+

--- a/src/main/java/com/example/bedwars/shop/ItemShopMenu.java
+++ b/src/main/java/com/example/bedwars/shop/ItemShopMenu.java
@@ -51,6 +51,9 @@ public final class ItemShopMenu {
     }
 
     int slot = 9;
+    if (cat == ShopCategory.TOOLS) {
+      inv.setItem(slot++, plugin.tools().createPickaxeIcon(p));
+    }
     for (ShopItem si : plugin.shopConfig().items(cat)) {
       Material mat = si.teamColored ? team.wool : si.mat;
       ItemStack it = new ItemStack(mat, si.amount);

--- a/src/main/java/com/example/bedwars/shop/ShopListener.java
+++ b/src/main/java/com/example/bedwars/shop/ShopListener.java
@@ -89,6 +89,14 @@ public final class ShopListener implements Listener {
       }
       int index = slot - 9;
       java.util.List<ShopItem> list = plugin.shopConfig().items(ih.cat);
+      if (ih.cat == ShopCategory.TOOLS) {
+        if (index == 0) {
+          plugin.tools().buyNextPick(p);
+          itemMenu.open(p, ih.arenaId, ih.team, ih.cat);
+          return;
+        }
+        index--;
+      }
       if (index < 0 || index >= list.size()) return;
       ShopItem si = list.get(index);
       if (PurchaseService.tryBuy(p, si.currency, si.cost)) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -142,6 +142,18 @@ anti_drop:
   leave_item: true
   selector_item: true
 
+tools:
+  pickaxe:
+    require_sequential: true
+    downgrade_on_death: false
+    unbreakable: true
+    no_drop: true
+    tiers:
+      1: { material: WOODEN_PICKAXE,  efficiency: 1, price: { IRON: 10 } }
+      2: { material: STONE_PICKAXE,   efficiency: 2, price: { IRON: 20 }, requires: 1 }
+      3: { material: IRON_PICKAXE,    efficiency: 3, price: { GOLD: 6  }, requires: 2 }
+      4: { material: DIAMOND_PICKAXE, efficiency: 4, price: { GOLD: 12 }, requires: 3 }
+
 fireball:
   enabled: true
   type: BIG        # BIG | SMALL

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -13,6 +13,8 @@ errors:
   no_build_generator: "&cImpossible de construire sur un générateur."
   cannot_remove_armor: "&cTu ne peux pas enlever ton armure."
   cannot_drop_sword: "&cTu ne peux pas jeter ton épée."
+  pickaxe:
+    seq: "&cTu dois acheter le niveau précédent d'abord."
 
 countdown:
   chat: "&eLa partie démarre dans &6{sec}s"
@@ -134,6 +136,14 @@ shop:
   bought: "&aAchat effectué: &f{item}."
   maxed: "&7Déjà au niveau maximal."
   trap-added: "&aPiège ajouté. File: {count}/3"
+  tools:
+    pickaxe:
+      title: "&bPioche"
+      current: "&7Actuel: &f{mat}&7 (Efficacité {eff})"
+      next: "&eProchain: &f{mat}&7 (Efficacité {eff}) &8• &6{price}"
+      max: "&aAu niveau maximum"
+      permanent: "&7Permanent • Réappliqué au respawn"
+      bought: "&aPioche améliorée vers &f{mat}&a (Efficacité {eff})"
 
 game:
   already-in: "&7Vous êtes déjà dans une arène."

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -97,30 +97,6 @@ TOOLS:
     meta: { unbreakable: true }
     grant_permanent_tool: SHEARS
 
-  - id: PICK_T1
-    icon: WOODEN_PICKAXE
-    name: "&fPioche en bois"
-    price: { IRON: 10 }
-    grant_pick_tier: 1
-  - id: PICK_T2
-    icon: STONE_PICKAXE
-    name: "&7Pioche en pierre"
-    price: { IRON: 20 }
-    requires_prev: PICK_T1
-    grant_pick_tier: 2
-  - id: PICK_T3
-    icon: IRON_PICKAXE
-    name: "&fPioche en fer"
-    price: { GOLD: 6 }
-    requires_prev: PICK_T2
-    grant_pick_tier: 3
-  - id: PICK_T4
-    icon: DIAMOND_PICKAXE
-    name: "&bPioche en diamant"
-    price: { GOLD: 12 }
-    requires_prev: PICK_T3
-    grant_pick_tier: 4
-
   - id: AXE_T1
     icon: WOODEN_AXE
     name: "&fHache en bois"


### PR DESCRIPTION
## Summary
- implement `ToolsService` and `ToolsListener` for tiered pickaxe upgrades, persistence and respawn handling
- add dynamic pickaxe entry to Tools shop menu and handle upgrade purchases
- add configuration and messages for pickaxe tiers

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dbadb9d10832985be1f901f195fd7