### PR TITLE
feat: add traps catalogue menu

### DIFF
--- a/src/main/java/com/example/bedwars/shop/TeamUpgradesMenu.java
+++ b/src/main/java/com/example/bedwars/shop/TeamUpgradesMenu.java
@@ -25,24 +25,42 @@ public final class TeamUpgradesMenu {
   public static final int SLOT_SHARP = 10;
   public static final int SLOT_PROT = 12;
   public static final int SLOT_HASTE = 14;
-  public static final int SLOT_HEAL = 16;
-  public static final int SLOT_FORGE = 28;
-  public static final int SLOT_TRAP = 30;
+  public static final int SLOT_TRAP_SHORTCUT = 16;
+  public static final int SLOT_FORGE = 19;
+  public static final int SLOT_HEAL = 21;
+  public static final int SLOT_TRAP_OPEN = 18;
+  public static final int SLOT_TRAP1 = 20;
+  public static final int SLOT_TRAP2 = 22;
+  public static final int SLOT_TRAP3 = 24;
+  public static final int SLOT_CLOSE = 26;
 
   public TeamUpgradesMenu(BedwarsPlugin plugin){ this.plugin = plugin; }
 
   public void open(Player p, String arenaId, TeamColor team) {
-    String title = plugin.messages().get("shop.upgrades-title");
-    Inventory inv = Bukkit.createInventory(new Holder(arenaId, team), 54, title);
+    String title = plugin.messages().get("menu.upgrades_title");
+    Inventory inv = Bukkit.createInventory(new Holder(arenaId, team), 27, title);
     TeamData td = plugin.arenas().get(arenaId).map(a->a.team(team)).orElse(null);
     TeamUpgradesState st = td != null ? td.upgrades() : new TeamUpgradesState();
 
-    inv.setItem(SLOT_SHARP, icon(Material.DIAMOND_SWORD, UpgradeType.SHARPNESS, st.sharpness()?1:0, p));
-    inv.setItem(SLOT_PROT, icon(Material.DIAMOND_BOOTS, UpgradeType.PROTECTION, st.protection(), p));
+    ItemStack filler = new ItemStack(Material.LIGHT_GRAY_STAINED_GLASS_PANE);
+    ItemMeta fm = filler.getItemMeta();
+    if (fm != null) { fm.setDisplayName(" "); filler.setItemMeta(fm); }
+    for (int i = 0; i < 9; i++) inv.setItem(i, filler);
+
+    inv.setItem(SLOT_SHARP, icon(Material.IRON_SWORD, UpgradeType.SHARPNESS, st.sharpness()?1:0, p));
+    inv.setItem(SLOT_PROT, icon(Material.IRON_CHESTPLATE, UpgradeType.PROTECTION, st.protection(), p));
     inv.setItem(SLOT_HASTE, icon(Material.GOLDEN_PICKAXE, UpgradeType.MANIC_MINER, st.manicMiner(), p));
-    inv.setItem(SLOT_HEAL, icon(Material.BEACON, UpgradeType.HEAL_POOL, st.healPool()?1:0, p));
+    inv.setItem(SLOT_TRAP_SHORTCUT, trapShortcutIcon(p));
+
     inv.setItem(SLOT_FORGE, icon(Material.FURNACE, UpgradeType.FORGE, st.forge(), p));
-    inv.setItem(SLOT_TRAP, trapIcon(st, p));
+    inv.setItem(SLOT_HEAL, icon(Material.BEACON, UpgradeType.HEAL_POOL, st.healPool()?1:0, p));
+
+    inv.setItem(SLOT_TRAP_OPEN, trapOpenIcon(st, p));
+    TrapType[] q = st.trapQueue().toArray(new TrapType[0]);
+    inv.setItem(SLOT_TRAP1, trapQueueIcon(q, 0));
+    inv.setItem(SLOT_TRAP2, trapQueueIcon(q, 1));
+    inv.setItem(SLOT_TRAP3, trapQueueIcon(q, 2));
+    inv.setItem(SLOT_CLOSE, closeIcon());
 
     p.openInventory(inv);
   }
@@ -66,18 +84,47 @@ public final class TeamUpgradesMenu {
     return it;
   }
 
-  private ItemStack trapIcon(TeamUpgradesState st, Player p) {
-    UpgradeService.TrapDef def = plugin.upgrades().trapDef(TrapType.ALARM);
+  private ItemStack trapOpenIcon(TeamUpgradesState st, Player p) {
     ItemStack it = new ItemStack(Material.TRIPWIRE_HOOK);
     ItemMeta im = it.getItemMeta();
-    if (im != null && def != null) {
-      im.setDisplayName(ChatColor.LIGHT_PURPLE + "Traps " + st.trapQueue().size() + "/3");
-      int cost = def.cost;
-      int have = plugin.upgrades().countDiamonds(p);
-      ChatColor col = have >= cost ? ChatColor.GRAY : ChatColor.RED;
-      im.setLore(java.util.List.of(col + "Coût : " + cost + "◆"));
+    if (im != null) {
+      im.setDisplayName(ChatColor.LIGHT_PURPLE + plugin.messages().get("menu.traps_title"));
+      im.setLore(java.util.List.of(ChatColor.GRAY + plugin.messages().get("shop.trap-added").replace("{count}", String.valueOf(st.trapQueue().size()))));
       it.setItemMeta(im);
     }
+    return it;
+  }
+
+  private ItemStack trapShortcutIcon(Player p) {
+    ItemStack it = new ItemStack(Material.REDSTONE_TORCH);
+    ItemMeta im = it.getItemMeta();
+    if (im != null) {
+      im.setDisplayName(ChatColor.LIGHT_PURPLE + plugin.messages().get("menu.traps_title"));
+      it.setItemMeta(im);
+    }
+    return it;
+  }
+
+  private ItemStack trapQueueIcon(TrapType[] q, int idx) {
+    if (idx < q.length) {
+      TrapType t = q[idx];
+      UpgradeService.TrapDef def = plugin.upgrades().trapDef(t);
+      Material mat = def != null ? def.icon : Material.PAPER;
+      ItemStack it = new ItemStack(mat);
+      ItemMeta im = it.getItemMeta();
+      if (im != null && def != null) { im.setDisplayName(ChatColor.WHITE + ChatColor.stripColor(ChatColor.translateAlternateColorCodes('&', def.name))); it.setItemMeta(im); }
+      return it;
+    }
+    ItemStack empty = new ItemStack(Material.LIGHT_GRAY_STAINED_GLASS_PANE);
+    ItemMeta em = empty.getItemMeta();
+    if (em != null) { em.setDisplayName(" "); empty.setItemMeta(em); }
+    return empty;
+  }
+
+  private ItemStack closeIcon() {
+    ItemStack it = new ItemStack(Material.BARRIER);
+    ItemMeta im = it.getItemMeta();
+    if (im != null) { im.setDisplayName(ChatColor.RED + plugin.messages().get("generic.reloaded")); it.setItemMeta(im); }
     return it;
   }
 

--- a/src/main/java/com/example/bedwars/shop/TrapsCatalogueMenu.java
+++ b/src/main/java/com/example/bedwars/shop/TrapsCatalogueMenu.java
@@ -1,0 +1,63 @@
+package com.example.bedwars.shop;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.TeamColor;
+import com.example.bedwars.arena.TeamData;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Menu listing all available traps to purchase.
+ */
+public final class TrapsCatalogueMenu {
+  private final BedwarsPlugin plugin;
+  public static final int SLOT_CLOSE = 26;
+
+  public TrapsCatalogueMenu(BedwarsPlugin plugin) { this.plugin = plugin; }
+
+  public void open(Player p, String arenaId, TeamColor team) {
+    String title = plugin.messages().get("menu.traps_title");
+    Inventory inv = Bukkit.createInventory(new Holder(arenaId, team), 27, title);
+    TeamData td = plugin.arenas().get(arenaId).map(a->a.team(team)).orElse(null);
+    TeamUpgradesState st = td != null ? td.upgrades() : new TeamUpgradesState();
+
+    ItemStack filler = new ItemStack(Material.LIGHT_GRAY_STAINED_GLASS_PANE);
+    ItemMeta fm = filler.getItemMeta();
+    if (fm != null) { fm.setDisplayName(" "); filler.setItemMeta(fm); }
+    for (int i = 0; i < 27; i++) inv.setItem(i, filler);
+
+    int slot = 10;
+    for (TrapType t : TrapType.values()) {
+      UpgradeService.TrapDef def = plugin.upgrades().trapDef(t);
+      if (def == null) continue;
+      ItemStack it = new ItemStack(def.icon);
+      ItemMeta im = it.getItemMeta();
+      if (im != null) {
+        im.setDisplayName(ChatColor.translateAlternateColorCodes('&', def.name));
+        im.setLore(java.util.List.of(ChatColor.GRAY + "Coût : " + def.cost + "◆"));
+        it.setItemMeta(im);
+      }
+      inv.setItem(slot, it);
+      slot += 2;
+    }
+
+    ItemStack close = new ItemStack(Material.BARRIER);
+    ItemMeta cm = close.getItemMeta();
+    if (cm != null) { cm.setDisplayName(ChatColor.RED + plugin.messages().get("generic.reloaded")); close.setItemMeta(cm); }
+    inv.setItem(SLOT_CLOSE, close);
+
+    p.openInventory(inv);
+  }
+
+  static final class Holder implements InventoryHolder {
+    final String arenaId; final TeamColor team;
+    Holder(String arenaId, TeamColor team){ this.arenaId = arenaId; this.team = team; }
+    @Override public Inventory getInventory(){ return null; }
+  }
+}

--- a/src/main/java/com/example/bedwars/shop/UpgradeService.java
+++ b/src/main/java/com/example/bedwars/shop/UpgradeService.java
@@ -37,8 +37,10 @@ public final class UpgradeService {
     public int costForLevel(int level) { return (level >=1 && level <= costs.length) ? costs[level-1] : Integer.MAX_VALUE; }
   }
   public static final class TrapDef {
-    public final int cost; public final String name;
-    public TrapDef(int cost, String name){ this.cost = cost; this.name = name; }
+    public final int cost; public final String name; public final Material icon;
+    public TrapDef(int cost, String name, Material icon){
+      this.cost = cost; this.name = name; this.icon = icon != null ? icon : Material.BARRIER;
+    }
   }
 
   private static int asInt(Object o, int def) {
@@ -94,7 +96,8 @@ public final class UpgradeService {
         try { t = TrapType.valueOf(id.toUpperCase()); } catch (Exception ex) { continue; }
         int cost = asInt(raw.get("cost"), 1);
         String name = String.valueOf(raw.getOrDefault("name", id));
-        traps.put(t, new TrapDef(cost, name));
+        Material icon = Material.matchMaterial(String.valueOf(raw.getOrDefault("icon", "TRIPWIRE_HOOK")));
+        traps.put(t, new TrapDef(cost, name, icon));
       }
     }
   }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -24,6 +24,8 @@ menu:
   team_mode_title: "&eMode d'équipes"
   running_locked: "&cAction impossible pendant une partie."
   team_selector_title: "&bChoisis ton équipe"
+  upgrades_title: "&bUpgrades & Traps"
+  traps_title: "&bPièges"
   team_disabled: "&8[hors service]"
   team_joined: "&aTu as rejoint &f{team}"
 

--- a/src/main/resources/upgrades.yml
+++ b/src/main/resources/upgrades.yml
@@ -31,6 +31,6 @@ upgrades:
   TRAPS:
     slots: 3
     catalogue:
-      - { id: ALARM, name: "&fAlarm", cost: 1 }
-      - { id: COUNTER, name: "&fCounter-Offensive", cost: 1 }
-      - { id: MINER_FATIGUE, name: "&fMiner Fatigue", cost: 1 }
+      - { id: ALARM, icon: REDSTONE_TORCH, name: "&fAlarm", cost: 1 }
+      - { id: COUNTER, icon: FEATHER, name: "&fCounter-Offensive", cost: 1 }
+      - { id: MINER_FATIGUE, icon: IRON_PICKAXE, name: "&fMiner Fatigue", cost: 1 }


### PR DESCRIPTION
## Summary
- redesign upgrades menu with trap queue and shortcut
- add trap catalogue menu and support icons from config
- extend upgrade service to read trap icons

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dc291aa6c8329bc003011c12e6cc3