### PR TITLE
feat: add axe progression and trap cost scaling

### DIFF
--- a/src/main/java/com/example/bedwars/services/ToolsService.java
+++ b/src/main/java/com/example/bedwars/services/ToolsService.java
@@ -22,16 +22,23 @@ import org.bukkit.inventory.meta.ItemMeta;
  */
 public final class ToolsService {
   public enum PickTier { T0, T1, T2, T3, T4 }
+  public enum AxeTier { T0, T1, T2, T3, T4 }
   public record PickSpec(Material mat, int eff, Currency cur, int cost, PickTier requires) {}
+  public record AxeSpec(Material mat, int eff, Currency cur, int cost, AxeTier requires) {}
 
   private final BedwarsPlugin plugin;
   private final Map<PickTier, PickSpec> specs = new EnumMap<>(PickTier.class);
+  private final Map<AxeTier, AxeSpec> axeSpecs = new EnumMap<>(AxeTier.class);
   private final Map<UUID, PlayerData> data = new HashMap<>();
   private final File dataDir;
-  private final boolean requireSequential;
-  private final boolean downgradeOnDeath;
-  private final boolean unbreakable;
-  private final boolean noDrop;
+  private final boolean pickRequireSequential;
+  private final boolean pickDowngradeOnDeath;
+  private final boolean pickUnbreakable;
+  private final boolean pickNoDrop;
+  private final boolean axeRequireSequential;
+  private final boolean axeDowngradeOnDeath;
+  private final boolean axeUnbreakable;
+  private final boolean axeNoDrop;
 
   private static final Enchantment EFFICIENCY_ENCH =
       resolveEnchant("DIG_SPEED", "EFFICIENCY", "efficiency");
@@ -68,7 +75,7 @@ public final class ToolsService {
 
   static final class PlayerData {
     PickTier pickTier = PickTier.T0;
-    int axeTier = 0;
+    AxeTier axeTier = AxeTier.T0;
     boolean hasShears = false;
   }
 
@@ -76,10 +83,10 @@ public final class ToolsService {
     this.plugin = plugin;
     ConfigurationSection root = plugin.getConfig().getConfigurationSection("tools.pickaxe");
     if (root == null) root = plugin.getConfig().createSection("tools.pickaxe");
-    this.requireSequential = root.getBoolean("require_sequential", true);
-    this.downgradeOnDeath = root.getBoolean("downgrade_on_death", false);
-    this.unbreakable = root.getBoolean("unbreakable", true);
-    this.noDrop = root.getBoolean("no_drop", true);
+    this.pickRequireSequential = root.getBoolean("require_sequential", true);
+    this.pickDowngradeOnDeath = root.getBoolean("downgrade_on_death", false);
+    this.pickUnbreakable = root.getBoolean("unbreakable", true);
+    this.pickNoDrop = root.getBoolean("no_drop", true);
     ConfigurationSection tiers = root.getConfigurationSection("tiers");
     if (tiers != null) {
       for (String k : tiers.getKeys(false)) {
@@ -103,6 +110,36 @@ public final class ToolsService {
         specs.put(PickTier.values()[idx], new PickSpec(mat, eff, cur, cost, req));
       }
     }
+
+    ConfigurationSection axeRoot = plugin.getConfig().getConfigurationSection("tools.axe");
+    if (axeRoot == null) axeRoot = plugin.getConfig().createSection("tools.axe");
+    this.axeRequireSequential = axeRoot.getBoolean("require_sequential", true);
+    this.axeDowngradeOnDeath = axeRoot.getBoolean("downgrade_on_death", false);
+    this.axeUnbreakable = axeRoot.getBoolean("unbreakable", true);
+    this.axeNoDrop = axeRoot.getBoolean("no_drop", true);
+    ConfigurationSection axeTiers = axeRoot.getConfigurationSection("tiers");
+    if (axeTiers != null) {
+      for (String k : axeTiers.getKeys(false)) {
+        int idx;
+        try { idx = Integer.parseInt(k); } catch (Exception ex) { continue; }
+        ConfigurationSection t = axeTiers.getConfigurationSection(k);
+        if (t == null) continue;
+        Material mat = Material.matchMaterial(t.getString("material", "WOODEN_AXE"));
+        int eff = t.getInt("efficiency", 1);
+        ConfigurationSection priceSec = t.getConfigurationSection("price");
+        Currency cur = Currency.IRON;
+        int cost = 0;
+        if (priceSec != null && !priceSec.getKeys(false).isEmpty()) {
+          String cKey = priceSec.getKeys(false).iterator().next();
+          try { cur = Currency.valueOf(cKey.toUpperCase(Locale.ROOT)); } catch (Exception ignore) {}
+          cost = priceSec.getInt(cKey);
+        }
+        AxeTier req = AxeTier.T0;
+        int reqI = t.getInt("requires", 0);
+        if (reqI >=0 && reqI < AxeTier.values().length) req = AxeTier.values()[reqI];
+        axeSpecs.put(AxeTier.values()[idx], new AxeSpec(mat, eff, cur, cost, req));
+      }
+    }
     this.dataDir = new File(plugin.getDataFolder(), "playerdata");
     dataDir.mkdirs();
   }
@@ -118,7 +155,8 @@ public final class ToolsService {
       YamlConfiguration y = YamlConfiguration.loadConfiguration(f);
       int pt = y.getInt("pickaxeTier", 0);
       if (pt >=0 && pt < PickTier.values().length) d.pickTier = PickTier.values()[pt];
-      d.axeTier = y.getInt("axeTier", 0);
+      int at = y.getInt("axeTier", 0);
+      if (at >=0 && at < AxeTier.values().length) d.axeTier = AxeTier.values()[at];
       d.hasShears = y.getBoolean("hasShears", false);
     }
     return d;
@@ -128,7 +166,7 @@ public final class ToolsService {
     File f = new File(dataDir, id.toString() + ".json");
     YamlConfiguration y = new YamlConfiguration();
     y.set("pickaxeTier", d.pickTier.ordinal());
-    y.set("axeTier", d.axeTier);
+    y.set("axeTier", d.axeTier.ordinal());
     y.set("hasShears", d.hasShears);
     try { y.save(f); } catch (IOException ex) { plugin.getLogger().warning("Save fail " + ex); }
   }
@@ -137,6 +175,7 @@ public final class ToolsService {
   public void save(Player p) { PlayerData d = data.get(p.getUniqueId()); if (d != null) saveData(p.getUniqueId(), d); }
 
   public PickTier next(PickTier cur){ return switch(cur){ case T0->PickTier.T1; case T1->PickTier.T2; case T2->PickTier.T3; case T3->PickTier.T4; default->PickTier.T4; }; }
+  public AxeTier next(AxeTier cur){ return switch(cur){ case T0->AxeTier.T1; case T1->AxeTier.T2; case T2->AxeTier.T3; case T3->AxeTier.T4; default->AxeTier.T4; }; }
 
   private static String displayMat(Material m) {
     String n = m.name().toLowerCase(Locale.ROOT).replace('_', ' ');
@@ -231,21 +270,111 @@ public final class ToolsService {
     if (slot >= 0) inv.setItem(slot, it); else inv.addItem(it);
   }
 
-  public void onRespawn(Player p) { givePick(p); }
+  public ItemStack createAxeIcon(Player p) {
+    PlayerData d = data(p);
+    AxeTier cur = d.axeTier;
+    AxeTier nxt = next(cur);
+    ItemStack it;
+    if (nxt == cur) {
+      it = new ItemStack(Material.EMERALD);
+    } else {
+      AxeSpec ns = axeSpecs.get(nxt);
+      it = new ItemStack(ns != null ? ns.mat() : Material.WOODEN_AXE);
+    }
+    ItemMeta im = it.getItemMeta();
+    if (im != null) {
+      im.setDisplayName(plugin.messages().get("shop.tools.axe.title"));
+      java.util.List<String> lore = new ArrayList<>();
+      AxeSpec cs = axeSpecs.get(cur);
+      if (cs != null && cur != AxeTier.T0) {
+        lore.add(plugin.messages().format("shop.tools.axe.current", Map.of("mat", displayMat(cs.mat()), "eff", cs.eff())));
+      } else {
+        lore.add(plugin.messages().format("shop.tools.axe.current", Map.of("mat", "Aucune", "eff", 0)));
+      }
+      if (nxt == cur) {
+        lore.add(plugin.messages().get("shop.tools.axe.max"));
+      } else {
+        AxeSpec ns = axeSpecs.get(nxt);
+        boolean can = PurchaseService.count(p, ns.cur()) >= ns.cost();
+        String price = (can ? ChatColor.GREEN : ChatColor.RED) + String.valueOf(ns.cost()) + " " + displayCurrency(ns.cur());
+        lore.add(plugin.messages().format("shop.tools.axe.next", Map.of("mat", displayMat(ns.mat()), "eff", ns.eff(), "price", price)));
+      }
+      lore.add(plugin.messages().get("shop.tools.axe.permanent"));
+      im.setLore(lore);
+      it.setItemMeta(im);
+    }
+    return it;
+  }
+
+  public boolean buyNextAxe(Player p) {
+    PlayerData d = data(p);
+    AxeTier cur = d.axeTier;
+    AxeTier nxt = next(cur);
+    if (nxt == cur) {
+      p.sendMessage(plugin.messages().get("shop.tools.axe.max"));
+      return false;
+    }
+    AxeSpec s = axeSpecs.get(nxt);
+    if (axeRequireSequential && s.requires() != cur) {
+      p.sendMessage(plugin.messages().get("errors.axe.seq"));
+      return false;
+    }
+    if (!PurchaseService.tryBuy(p, s.cur(), s.cost())) {
+      plugin.messages().send(p, "shop.need", Map.of("amount", s.cost(), "currency", s.cur().name()));
+      return false;
+    }
+    d.axeTier = nxt;
+    giveAxe(p, s);
+    plugin.messages().send(p, "shop.tools.axe.bought", Map.of("mat", displayMat(s.mat()), "eff", s.eff()));
+    save(p);
+    return true;
+  }
+
+  public void giveAxe(Player p) {
+    PlayerData d = data(p);
+    AxeSpec s = axeSpecs.get(d.axeTier);
+    if (s != null) giveAxe(p, s);
+  }
+
+  private void giveAxe(Player p, AxeSpec s) {
+    ItemStack it = new ItemStack(s.mat());
+    ItemMeta m = it.getItemMeta();
+    if (m != null) {
+      m.addEnchant(EFFICIENCY_ENCH, s.eff(), true);
+      if (axeUnbreakable) m.setUnbreakable(true);
+      it.setItemMeta(m);
+    }
+    Inventory inv = p.getInventory();
+    int slot = -1;
+    for (int i = 0; i < inv.getSize(); i++) {
+      ItemStack cur = inv.getItem(i);
+      if (cur != null && cur.getType().name().endsWith("_AXE")) { slot = i; break; }
+    }
+    if (slot >= 0) inv.setItem(slot, it); else inv.addItem(it);
+  }
+
+  public void onRespawn(Player p) { givePick(p); giveAxe(p); }
 
   public void onDeath(Player p, java.util.List<ItemStack> drops) {
     PlayerData d = data(p);
-    if (noDrop) drops.removeIf(is -> is.getType().name().endsWith("_PICKAXE"));
-    if (downgradeOnDeath && d.pickTier.ordinal() > 1) {
+    if (pickNoDrop) drops.removeIf(is -> is.getType().name().endsWith("_PICKAXE"));
+    if (axeNoDrop) drops.removeIf(is -> is.getType().name().endsWith("_AXE"));
+    if (pickDowngradeOnDeath && d.pickTier.ordinal() > 1) {
       d.pickTier = PickTier.values()[d.pickTier.ordinal() - 1];
+    }
+    if (axeDowngradeOnDeath && d.axeTier.ordinal() > 1) {
+      d.axeTier = AxeTier.values()[d.axeTier.ordinal() - 1];
     }
   }
 
   public boolean canDrop(Player p, ItemStack it) {
-    if (!noDrop) return true;
-    if (it.getType().name().endsWith("_PICKAXE")) {
+    if ((pickNoDrop && it.getType().name().endsWith("_PICKAXE"))) {
       PlayerData d = data(p);
       return d.pickTier == PickTier.T0;
+    }
+    if ((axeNoDrop && it.getType().name().endsWith("_AXE"))) {
+      PlayerData d = data(p);
+      return d.axeTier == AxeTier.T0;
     }
     return true;
   }

--- a/src/main/java/com/example/bedwars/shop/ItemShopMenu.java
+++ b/src/main/java/com/example/bedwars/shop/ItemShopMenu.java
@@ -21,6 +21,8 @@ import org.bukkit.inventory.meta.ItemMeta;
 public final class ItemShopMenu {
   private final BedwarsPlugin plugin;
   private static final Map<ShopCategory, Material> ICONS = new EnumMap<>(ShopCategory.class);
+  private static final int GRID_ROWS = 4, GRID_COLS = 7, GRID_ORIGIN = 19, ROW_STRIDE = 9;
+  private static int slotAt(int r, int c){ return GRID_ORIGIN + r*ROW_STRIDE + c; }
   static {
     ICONS.put(ShopCategory.BLOCKS, Material.CLAY);
     ICONS.put(ShopCategory.MELEE, Material.IRON_SWORD);
@@ -50,9 +52,10 @@ public final class ItemShopMenu {
       inv.setItem(i++, it);
     }
 
-    int slot = 9;
+    List<ItemStack> items = new ArrayList<>();
     if (cat == ShopCategory.TOOLS) {
-      inv.setItem(slot++, plugin.tools().createPickaxeIcon(p));
+      items.add(plugin.tools().createPickaxeIcon(p));
+      items.add(plugin.tools().createAxeIcon(p));
     }
     for (ShopItem si : plugin.shopConfig().items(cat)) {
       Material mat = si.teamColored ? team.wool : si.mat;
@@ -67,7 +70,12 @@ public final class ItemShopMenu {
         si.enchants.forEach((e,l) -> im.addEnchant(e, l, true));
         it.setItemMeta(im);
       }
-      inv.setItem(slot++, it);
+      items.add(it);
+    }
+    for (int idx = 0; idx < items.size() && idx < GRID_ROWS*GRID_COLS; idx++) {
+      int r = idx / GRID_COLS;
+      int c = idx % GRID_COLS;
+      inv.setItem(slotAt(r,c), items.get(idx));
     }
 
     p.openInventory(inv);

--- a/src/main/java/com/example/bedwars/shop/TeamUpgradesMenu.java
+++ b/src/main/java/com/example/bedwars/shop/TeamUpgradesMenu.java
@@ -89,7 +89,12 @@ public final class TeamUpgradesMenu {
     ItemMeta im = it.getItemMeta();
     if (im != null) {
       im.setDisplayName(ChatColor.LIGHT_PURPLE + plugin.messages().get("menu.traps_title"));
-      im.setLore(java.util.List.of(ChatColor.GRAY + plugin.messages().get("shop.trap-added").replace("{count}", String.valueOf(st.trapQueue().size()))));
+      int cost = plugin.upgrades().trapCost(st.trapQueue().size());
+      String line1 = ChatColor.GRAY + plugin.messages().get("shop.trap-added")
+          .replace("{count}", String.valueOf(st.trapQueue().size()))
+          .replace("{max}", String.valueOf(plugin.upgrades().trapSlots()));
+      String line2 = ChatColor.DARK_GRAY + plugin.messages().format("traps.next_cost", java.util.Map.of("cost", cost));
+      im.setLore(java.util.List.of(line1, line2));
       it.setItemMeta(im);
     }
     return it;

--- a/src/main/java/com/example/bedwars/shop/TrapType.java
+++ b/src/main/java/com/example/bedwars/shop/TrapType.java
@@ -4,5 +4,8 @@ package com.example.bedwars.shop;
  * Types of defensive traps.
  */
 public enum TrapType {
-  ALARM, MINING_FATIGUE, COUNTER_OFFENSIVE
+  ALARM,
+  MINER_FATIGUE,
+  BLIND_SLOW,
+  COUNTER
 }

--- a/src/main/java/com/example/bedwars/shop/TrapsCatalogueMenu.java
+++ b/src/main/java/com/example/bedwars/shop/TrapsCatalogueMenu.java
@@ -40,7 +40,8 @@ public final class TrapsCatalogueMenu {
       ItemMeta im = it.getItemMeta();
       if (im != null) {
         im.setDisplayName(ChatColor.translateAlternateColorCodes('&', def.name));
-        im.setLore(java.util.List.of(ChatColor.GRAY + "Coût : " + def.cost + "◆"));
+        int cost = plugin.upgrades().trapCost(st.trapQueue().size());
+        im.setLore(java.util.List.of(ChatColor.GRAY + "Coût : " + cost + "◆"));
         it.setItemMeta(im);
       }
       inv.setItem(slot, it);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -154,6 +154,17 @@ tools:
       3: { material: IRON_PICKAXE,    efficiency: 3, price: { GOLD: 6  }, requires: 2 }
       4: { material: DIAMOND_PICKAXE, efficiency: 4, price: { GOLD: 12 }, requires: 3 }
 
+  axe:
+    require_sequential: true
+    downgrade_on_death: false
+    unbreakable: true
+    no_drop: true
+    tiers:
+      1: { material: WOODEN_AXE,  efficiency: 1, price: { IRON: 10 } }
+      2: { material: STONE_AXE,   efficiency: 2, price: { IRON: 20 }, requires: 1 }
+      3: { material: IRON_AXE,    efficiency: 3, price: { GOLD: 6  }, requires: 2 }
+      4: { material: DIAMOND_AXE, efficiency: 4, price: { GOLD: 12 }, requires: 3 }
+
 fireball:
   enabled: true
   type: BIG        # BIG | SMALL

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -15,6 +15,8 @@ errors:
   cannot_drop_sword: "&cTu ne peux pas jeter ton épée."
   pickaxe:
     seq: "&cTu dois acheter le niveau précédent d'abord."
+  axe:
+    seq: "&cTu dois acheter le niveau précédent d'abord."
 
 countdown:
   chat: "&eLa partie démarre dans &6{sec}s"
@@ -137,7 +139,7 @@ shop:
   need: "&cIl manque &f{amount}&7x {currency}."
   bought: "&aAchat effectué: &f{item}."
   maxed: "&7Déjà au niveau maximal."
-  trap-added: "&aPiège ajouté. File: {count}/3"
+  trap-added: "&aPiège ajouté. File: {count}/{max}"
   tools:
     pickaxe:
       title: "&bPioche"
@@ -146,6 +148,16 @@ shop:
       max: "&aAu niveau maximum"
       permanent: "&7Permanent • Réappliqué au respawn"
       bought: "&aPioche améliorée vers &f{mat}&a (Efficacité {eff})"
+    axe:
+      title: "&bHache"
+      current: "&7Actuel: &f{mat}&7 (Efficacité {eff})"
+      next: "&eProchain: &f{mat}&7 (Efficacité {eff}) &8• &6{price}"
+      max: "&aAu niveau maximum"
+      permanent: "&7Permanent • Réappliqué au respawn"
+      bought: "&aHache améliorée vers &f{mat}&a (Efficacité {eff})"
+
+traps:
+  next_cost: "&7Coût du prochain piège: &f{cost}◆"
 
 game:
   already-in: "&7Vous êtes déjà dans une arène."

--- a/src/main/resources/shop.yml
+++ b/src/main/resources/shop.yml
@@ -97,30 +97,6 @@ TOOLS:
     meta: { unbreakable: true }
     grant_permanent_tool: SHEARS
 
-  - id: AXE_T1
-    icon: WOODEN_AXE
-    name: "&fHache en bois"
-    price: { IRON: 10 }
-    grant_axe_tier: 1
-  - id: AXE_T2
-    icon: STONE_AXE
-    name: "&7Hache en pierre"
-    price: { IRON: 20 }
-    requires_prev: AXE_T1
-    grant_axe_tier: 2
-  - id: AXE_T3
-    icon: IRON_AXE
-    name: "&fHache en fer"
-    price: { GOLD: 6 }
-    requires_prev: AXE_T2
-    grant_axe_tier: 3
-  - id: AXE_T4
-    icon: DIAMOND_AXE
-    name: "&bHache en diamant"
-    price: { GOLD: 12 }
-    requires_prev: AXE_T3
-    grant_axe_tier: 4
-
 RANGED:
   - id: BOW
     icon: BOW

--- a/src/main/resources/upgrades.yml
+++ b/src/main/resources/upgrades.yml
@@ -30,7 +30,9 @@ upgrades:
     cost: 1
   TRAPS:
     slots: 3
+    queue_costs: [1, 2, 4]
     catalogue:
-      - { id: ALARM, icon: REDSTONE_TORCH, name: "&fAlarm", cost: 1 }
-      - { id: COUNTER, icon: FEATHER, name: "&fCounter-Offensive", cost: 1 }
-      - { id: MINER_FATIGUE, icon: IRON_PICKAXE, name: "&fMiner Fatigue", cost: 1 }
+      - { id: ALARM,         icon: REDSTONE_TORCH,  name: "&fAlarm" }
+      - { id: MINER_FATIGUE, icon: IRON_PICKAXE,    name: "&fMiner Fatigue" }
+      - { id: BLIND_SLOW,    icon: FERMENTED_SPIDER_EYE, name: "&fIt's a Trap!" }
+      - { id: COUNTER,       icon: FEATHER,         name: "&fCounter-Offensive" }


### PR DESCRIPTION
## Summary
- fix shop item grid positioning and add dynamic axe icon
- implement sequential axe tiers with persistence and anti-drop
- extend traps and upgrades: apply sharpness to axes and scale trap costs 1/2/4

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dcdb3a8608329b19b09310fee83ea