### PR TITLE
Fix ToolsService compile errors and config usage

### DIFF
--- a/src/main/java/com/example/bedwars/services/ToolsService.java
+++ b/src/main/java/com/example/bedwars/services/ToolsService.java
@@ -231,7 +231,7 @@ public final class ToolsService {
       return false;
     }
     PickSpec s = specs.get(nxt);
-    if (requireSequential && s.requires() != cur) {
+    if (pickRequireSequential && s.requires() != cur) {
       p.sendMessage(plugin.messages().get("errors.pickaxe.seq"));
       return false;
     }
@@ -258,7 +258,7 @@ public final class ToolsService {
     if (m != null) {
       // ignore level restriction so custom efficiency can exceed vanilla limits
       m.addEnchant(EFFICIENCY_ENCH, s.eff(), true);
-      if (unbreakable) m.setUnbreakable(true);
+      if (pickUnbreakable) m.setUnbreakable(true);
       it.setItemMeta(m);
     }
     Inventory inv = p.getInventory();


### PR DESCRIPTION
## Summary
- Reference pickaxe sequential purchase flag with `pickRequireSequential`
- Use `pickUnbreakable` config flag when creating pickaxes

## Testing
- ⚠️ `mvn -q package` *(plugin resolution failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dd2c20ac483299bc6a81483d97905