### PR TITLE
feat: cleanup placed blocks after games

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Plugin BedWars pour Spigot/Paper 1.21.
 Permissions globales : `bedwars.admin.*` (ops par défaut) et gameplay :
 `bedwars.menu.rules`, `bedwars.build.place`.
 
+## Nettoyage des blocs
+À la fin d'une partie, tous les blocs posés sont supprimés pour rendre la carte
+propre. Le processus est étalé sur plusieurs ticks afin d'éviter les lags :
+ajustez `cleanup.blocks_per_tick` dans `config.yml` (400 par défaut) selon vos
+performances.
+
 ## Captures
 Captures d'écran à insérer ici.
 

--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -52,6 +52,7 @@ import com.example.bedwars.border.BorderService;
 import com.example.bedwars.border.BorderMoveListener;
 import com.example.bedwars.border.BorderBuildListener;
 import com.example.bedwars.border.BorderStateListener;
+import com.example.bedwars.arena.GameState;
 
 public final class BedwarsPlugin extends JavaPlugin {
 
@@ -173,7 +174,14 @@ public final class BedwarsPlugin extends JavaPlugin {
 
   @Override
   public void onDisable() {
-    if (arenaManager != null) arenaManager.saveAll();
+    if (arenaManager != null) {
+      arenaManager.all().forEach(a -> {
+        if (a.state() == GameState.RUNNING && buildRules != null) {
+          buildRules.cleanupPlacedSync(a);
+        }
+      });
+      arenaManager.saveAll();
+    }
     if (npcManager != null) {
       arenaManager.all().forEach(npcManager::despawnAll);
     }

--- a/src/main/java/com/example/bedwars/game/GameService.java
+++ b/src/main/java/com/example/bedwars/game/GameService.java
@@ -227,7 +227,7 @@ public final class GameService {
     }
     plugin.generators().cleanupArena(a.id());
     if (plugin.getConfig().getBoolean("reset.clear_placed_blocks_on_end", true)) {
-      plugin.buildRules().clearArenaBlocks(a);
+      plugin.buildRules().cleanupPlaced(a);
     }
     Integer timer = timerTasks.remove(a.id());
     if (timer != null) Bukkit.getScheduler().cancelTask(timer);

--- a/src/main/java/com/example/bedwars/listeners/EntityExplodeListener.java
+++ b/src/main/java/com/example/bedwars/listeners/EntityExplodeListener.java
@@ -28,10 +28,11 @@ public final class EntityExplodeListener implements Listener {
     if (!restrict) return;
     e.blockList().removeIf(b -> {
       if (Tag.BEDS.isTagged(b.getType())) return true;
-      if (!b.hasMetadata("bw_placed")) return true;
-      String arena = buildRules.arenaAt(b.getLocation());
-      if (arena == null) return true;
-      buildRules.removePlaced(arena, b.getLocation());
+      String arenaId = buildRules.arenaAt(b.getLocation());
+      if (arenaId == null) return true;
+      var arenaOpt = plugin.arenas().get(arenaId);
+      if (arenaOpt.isEmpty()) return true;
+      buildRules.removePlaced(arenaOpt.get(), b.getLocation());
       return false;
     });
   }

--- a/src/main/java/com/example/bedwars/listeners/TntListener.java
+++ b/src/main/java/com/example/bedwars/listeners/TntListener.java
@@ -44,7 +44,7 @@ public final class TntListener implements Listener {
     Location loc = e.getBlockPlaced().getLocation().add(0.5, 0, 0.5);
     e.setCancelled(true);
     e.getBlockPlaced().setType(Material.AIR);
-    buildRules.removePlaced(arenaId, e.getBlockPlaced().getLocation());
+    buildRules.removePlaced(a, e.getBlockPlaced().getLocation());
     TNTPrimed t = (TNTPrimed) loc.getWorld().spawnEntity(loc, EntityType.TNT);
     t.setFuseTicks(plugin.getConfig().getInt("tnt.fuse_ticks", 40));
     if (plugin.getConfig().getBoolean("tnt.attribute_owner", true)) t.setSource(p);

--- a/src/main/java/com/example/bedwars/ops/Keys.java
+++ b/src/main/java/com/example/bedwars/ops/Keys.java
@@ -20,7 +20,6 @@ public final class Keys {
   private final NamespacedKey GEN_HOLO;
   private final NamespacedKey GEN_CAP;
   private final NamespacedKey BW_ITEM;
-  private final NamespacedKey BW_PLACED;
 
   public Keys(Plugin plugin) {
     this.ARENA_ID = new NamespacedKey(plugin, "arena_id");
@@ -32,7 +31,6 @@ public final class Keys {
     this.GEN_HOLO = new NamespacedKey(plugin, "gen_holo");
     this.GEN_CAP = new NamespacedKey(plugin, "gen_cap");
     this.BW_ITEM = new NamespacedKey(plugin, "bw_item");
-    this.BW_PLACED = new NamespacedKey(plugin, "bw_placed");
   }
 
   public NamespacedKey ARENA_ID() { return ARENA_ID; }
@@ -52,7 +50,5 @@ public final class Keys {
   public NamespacedKey GEN_CAP() { return GEN_CAP; }
 
   public NamespacedKey BW_ITEM() { return BW_ITEM; }
-
-  public NamespacedKey BW_PLACED() { return BW_PLACED; }
 }
 

--- a/src/main/java/com/example/bedwars/services/ArenaCleaner.java
+++ b/src/main/java/com/example/bedwars/services/ArenaCleaner.java
@@ -1,0 +1,83 @@
+package com.example.bedwars.services;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.arena.Arena;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.shorts.ShortIterator;
+import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * Removes blocks recorded in {@link PlacedBlocksStore} progressively to avoid
+ * lag spikes. Designed to be triggered at the end of a game.
+ */
+public final class ArenaCleaner {
+  private final BedwarsPlugin plugin;
+  private final PlacedBlocksStore store;
+  private final int blocksPerTick;
+
+  public ArenaCleaner(BedwarsPlugin plugin, PlacedBlocksStore store) {
+    this.plugin = plugin;
+    this.store = store;
+    this.blocksPerTick = plugin.getConfig().getInt("cleanup.blocks_per_tick", 400);
+  }
+
+  /** Start an asynchronous, budgeted cleanup task for the arena. */
+  public BukkitTask cleanupPlacedBlocks(Arena a) {
+    World w = a.world();
+    var it = store.chunks(a).iterator();
+    final BukkitTask[] handle = new BukkitTask[1];
+    handle[0] = Bukkit.getScheduler().runTaskTimer(plugin, () -> {
+      int budget = blocksPerTick;
+      while (it.hasNext() && budget > 0) {
+        Long2ObjectMap.Entry<ShortOpenHashSet> e = it.next();
+        int chunkX = (int) (e.getLongKey() >> 32);
+        int chunkZ = (int) e.getLongKey();
+        Chunk c = w.getChunkAt(chunkX, chunkZ);
+        ShortOpenHashSet set = e.getValue();
+        ShortIterator si = set.iterator();
+        while (si.hasNext() && budget-- > 0) {
+          short idx = si.nextShort();
+          int y = (idx >> 8) & 0xFF;
+          int lx = (idx >> 4) & 0xF;
+          int lz = idx & 0xF;
+          Block b = c.getBlock((chunkX << 4) + lx, y, (chunkZ << 4) + lz);
+          b.setType(Material.AIR, false);
+        }
+        if (set.isEmpty()) it.remove();
+      }
+      if (!it.hasNext()) {
+        store.clear(a);
+        handle[0].cancel();
+      }
+    }, 1L, 1L);
+    return handle[0];
+  }
+
+  /** Remove all recorded blocks synchronously (used on plugin disable). */
+  public void cleanupSync(Arena a) {
+    World w = a.world();
+    for (Long2ObjectMap.Entry<ShortOpenHashSet> e : store.chunks(a)) {
+      int chunkX = (int) (e.getLongKey() >> 32);
+      int chunkZ = (int) e.getLongKey();
+      Chunk c = w.getChunkAt(chunkX, chunkZ);
+      ShortOpenHashSet set = e.getValue();
+      ShortIterator si = set.iterator();
+      while (si.hasNext()) {
+        short idx = si.nextShort();
+        int y = (idx >> 8) & 0xFF;
+        int lx = (idx >> 4) & 0xF;
+        int lz = idx & 0xF;
+        Block b = c.getBlock((chunkX << 4) + lx, y, (chunkZ << 4) + lz);
+        b.setType(Material.AIR, false);
+      }
+    }
+    store.clear(a);
+  }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -239,6 +239,9 @@ reset:
   preserve_on_disable: true
   clear_placed_blocks_on_end: true
 
+cleanup:
+  blocks_per_tick: 400
+
 lighting:
   force_day: true
   day_time: 6000


### PR DESCRIPTION
## Summary
- track player and plugin placed blocks per arena
- progressively remove tracked blocks when games end and on plugin disable
- document cleanup controls in config and README

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dd642efec8329892659bd563b507c