### PR TITLE
feat: central lobby handling

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -78,6 +78,9 @@ public final class BedwarsPlugin extends JavaPlugin {
   private DeathRespawnService deathService;
   private LobbyItemsService lobbyItems;
   private TeamSelectMenu teamSelectMenu;
+  private com.example.bedwars.lobby.LobbyLocationService lobbyLocation;
+  private com.example.bedwars.game.PreJoinSnapshotService snapshotService;
+  private com.example.bedwars.lobby.LobbyService lobbyService;
   private com.example.bedwars.hud.ScoreboardManager scoreboardManager;
   private com.example.bedwars.hud.ActionBarBus actionBarBus;
   private RotationManager rotationManager;
@@ -109,6 +112,9 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.gameMessages = new GameMessages(this, contextService);
     this.lobbyItems = new LobbyItemsService(this);
     this.teamSelectMenu = new TeamSelectMenu(this, contextService);
+    this.lobbyLocation = new com.example.bedwars.lobby.LobbyLocationService(this);
+    this.snapshotService = new com.example.bedwars.game.PreJoinSnapshotService();
+    this.lobbyService = new com.example.bedwars.lobby.LobbyService(this, contextService, lobbyLocation, snapshotService);
     this.lightingService = new LightingService(this);
     this.borderService = new BorderService(this);
     for (Arena a : this.arenaManager.all()) {
@@ -119,7 +125,7 @@ public final class BedwarsPlugin extends JavaPlugin {
     this.boundaryPolicy = new com.example.bedwars.game.ArenaBoundaryPolicy(
         getConfig().getInt("bounds.min_y", -64),
         getConfig().getInt("bounds.void_kill_y", -60));
-    this.gameService = new GameService(this, contextService, teamAssignment, kitService, spectatorService, gameMessages, lobbyItems);
+    this.gameService = new GameService(this, contextService, teamAssignment, kitService, spectatorService, gameMessages, lobbyItems, snapshotService);
     this.deathService = new DeathRespawnService(this, contextService, kitService, spectatorService, gameMessages, gameService);
     this.gameService.setDeathService(deathService);
     this.upgradeService = new UpgradeService(this, contextService);
@@ -153,7 +159,7 @@ public final class BedwarsPlugin extends JavaPlugin {
     getServer().getPluginManager().registerEvents(new ShopListener(this, contextService), this);
     getServer().getPluginManager().registerEvents(new UpgradeApplyListener(this, contextService), this);
     getServer().getPluginManager().registerEvents(new GameStateListener(this), this);
-    getServer().getPluginManager().registerEvents(new JoinLeaveListener(gameService), this);
+    getServer().getPluginManager().registerEvents(new JoinLeaveListener(lobbyService), this);
     getServer().getPluginManager().registerEvents(new BedListener(this, gameService, contextService), this);
     getServer().getPluginManager().registerEvents(new DeathListener(this, deathService, contextService), this);
     getServer().getPluginManager().registerEvents(new VoidFailSafeListener(this, contextService), this);
@@ -163,7 +169,7 @@ public final class BedwarsPlugin extends JavaPlugin {
     getServer().getPluginManager().registerEvents(new EntityExplodeListener(this, buildRules), this);
     getServer().getPluginManager().registerEvents(new TntListener(this, contextService, buildRules), this);
     getServer().getPluginManager().registerEvents(teamSelectMenu, this);
-    getServer().getPluginManager().registerEvents(new LobbyListener(this, lobbyItems, teamSelectMenu, contextService, gameService), this);
+    getServer().getPluginManager().registerEvents(new LobbyListener(this, lobbyItems, teamSelectMenu, contextService, gameService, lobbyService), this);
     getServer().getPluginManager().registerEvents(new CompassListener(this, contextService, teamSelectMenu), this);
     getServer().getPluginManager().registerEvents(new ArmorLockListener(this, contextService), this);
     getServer().getPluginManager().registerEvents(new GameplayListener(this, contextService, lobbyItems), this);
@@ -242,4 +248,5 @@ public final class BedwarsPlugin extends JavaPlugin {
   public BorderService border() { return borderService; }
   public com.example.bedwars.services.ToolsService tools() { return toolsService; }
   public com.example.bedwars.game.ArenaBoundaryPolicy bounds() { return boundaryPolicy; }
+  public com.example.bedwars.lobby.LobbyService lobby() { return lobbyService; }
 }

--- a/src/main/java/com/example/bedwars/command/BwAdminCommand.java
+++ b/src/main/java/com/example/bedwars/command/BwAdminCommand.java
@@ -47,6 +47,20 @@ public final class BwAdminCommand implements CommandExecutor {
       return true;
     }
 
+    if (args[0].equalsIgnoreCase("lobby")) {
+      if (!sender.hasPermission("bedwars.admin.lobby")) {
+        sender.sendMessage(plugin.messages().get("errors.no_perm"));
+        return true;
+      }
+      if (args.length >= 2 && args[1].equalsIgnoreCase("set") && sender instanceof Player p) {
+        plugin.lobby().location().setFrom(p);
+        sender.sendMessage(plugin.messages().get("lobby.set_ok"));
+      } else {
+        sender.sendMessage(plugin.messages().get("lobby.missing"));
+      }
+      return true;
+    }
+
     if (args[0].equalsIgnoreCase("game")) {
       if (!sender.hasPermission("bedwars.admin.game")) {
         sender.sendMessage(plugin.messages().get("errors.no_perm"));

--- a/src/main/java/com/example/bedwars/command/BwCommand.java
+++ b/src/main/java/com/example/bedwars/command/BwCommand.java
@@ -13,10 +13,12 @@ import org.bukkit.entity.Player;
 public final class BwCommand implements CommandExecutor {
   private final BedwarsPlugin plugin;
   private final GameService game;
+  private final com.example.bedwars.lobby.LobbyService lobby;
 
   public BwCommand(BedwarsPlugin plugin) {
     this.plugin = plugin;
     this.game = plugin.game();
+    this.lobby = plugin.lobby();
   }
 
   @Override
@@ -35,7 +37,7 @@ public final class BwCommand implements CommandExecutor {
           game.join(player, args[1]);
           return true;
         case "leave":
-          game.leave(player, true);
+          lobby.sendToLobby(player, com.example.bedwars.lobby.LobbyService.Reason.COMMAND);
           return true;
         case "team":
           if (args.length < 2) return true;

--- a/src/main/java/com/example/bedwars/game/PreJoinSnapshotService.java
+++ b/src/main/java/com/example/bedwars/game/PreJoinSnapshotService.java
@@ -1,0 +1,33 @@
+package com.example.bedwars.game;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/** Stores a snapshot of a player's state before joining an arena. */
+public final class PreJoinSnapshotService {
+  private final Map<UUID, Snapshot> snapshots = new HashMap<>();
+
+  private record Snapshot(ItemStack[] contents, ItemStack[] armor, GameMode mode) {}
+
+  public void capture(Player p) {
+    snapshots.put(p.getUniqueId(),
+        new Snapshot(p.getInventory().getContents(),
+            p.getInventory().getArmorContents(), p.getGameMode()));
+  }
+
+  public void restore(Player p) {
+    Optional.ofNullable(snapshots.remove(p.getUniqueId())).ifPresentOrElse(s -> {
+      p.getInventory().setContents(s.contents());
+      p.getInventory().setArmorContents(s.armor());
+      p.setGameMode(s.mode());
+    }, () -> {
+      p.getInventory().clear();
+      p.getInventory().setArmorContents(null);
+    });
+  }
+}

--- a/src/main/java/com/example/bedwars/listeners/JoinLeaveListener.java
+++ b/src/main/java/com/example/bedwars/listeners/JoinLeaveListener.java
@@ -1,20 +1,20 @@
 package com.example.bedwars.listeners;
 
-import com.example.bedwars.game.GameService;
+import com.example.bedwars.lobby.LobbyService;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 /** Handles players leaving the server during games. */
 public final class JoinLeaveListener implements Listener {
-  private final GameService game;
+  private final LobbyService lobby;
 
-  public JoinLeaveListener(GameService game) {
-    this.game = game;
+  public JoinLeaveListener(LobbyService lobby) {
+    this.lobby = lobby;
   }
 
   @EventHandler
   public void onQuit(PlayerQuitEvent e) {
-    game.leave(e.getPlayer(), false);
+    lobby.sendToLobby(e.getPlayer(), LobbyService.Reason.DISCONNECT);
   }
 }

--- a/src/main/java/com/example/bedwars/lobby/LobbyItemsService.java
+++ b/src/main/java/com/example/bedwars/lobby/LobbyItemsService.java
@@ -14,13 +14,15 @@ public final class LobbyItemsService {
   private final int teamSelectorSlot;
   private final ItemStack leaveItem;
   private final int leaveItemSlot;
+  private final boolean leaveLocked;
 
   public LobbyItemsService(BedwarsPlugin plugin) {
     this.plugin = plugin;
     this.teamSelector = createItem("items.team_selector");
     this.teamSelectorSlot = plugin.getConfig().getInt("items.team_selector.slot", 0);
-    this.leaveItem = createItem("items.leave_arena");
-    this.leaveItemSlot = plugin.getConfig().getInt("items.leave_arena.slot", 8);
+    this.leaveItem = createLeaveItem();
+    this.leaveItemSlot = plugin.getConfig().getInt("items.leave.slot", 8);
+    this.leaveLocked = plugin.getConfig().getBoolean("items.leave.lock", true);
   }
 
   private ItemStack createItem(String path) {
@@ -35,6 +37,24 @@ public final class LobbyItemsService {
     return it;
   }
 
+  private ItemStack createLeaveItem() {
+    String mat = plugin.getConfig().getString("items.leave.material", "DARK_OAK_DOOR");
+    Material m = Material.matchMaterial(mat);
+    if (m == null) m = Material.DARK_OAK_DOOR;
+    String name = ChatColor.translateAlternateColorCodes('&',
+        plugin.getConfig().getString("items.leave.name", ""));
+    java.util.List<String> lore = plugin.getConfig().getStringList("items.leave.lore");
+    ItemStack it = new ItemStack(m);
+    ItemMeta meta = it.getItemMeta();
+    if (meta != null) {
+      meta.setDisplayName(name);
+      if (!lore.isEmpty()) meta.setLore(lore.stream().map(s -> ChatColor.translateAlternateColorCodes('&', s)).toList());
+      meta.getPersistentDataContainer().set(plugin.keys().BW_ITEM(), org.bukkit.persistence.PersistentDataType.STRING, "leave");
+      it.setItemMeta(meta);
+    }
+    return it;
+  }
+
   public void giveLobbyItems(Player p) {
     p.getInventory().clear();
     p.getInventory().setItem(teamSelectorSlot, teamSelector.clone());
@@ -46,8 +66,16 @@ public final class LobbyItemsService {
   }
 
   public boolean isLeaveItem(ItemStack it) {
-    return it != null && it.isSimilar(leaveItem);
+    if (it == null) return false;
+    ItemMeta meta = it.getItemMeta();
+    if (meta == null) return false;
+    var pdc = meta.getPersistentDataContainer();
+    var key = plugin.keys().BW_ITEM();
+    return pdc.has(key, org.bukkit.persistence.PersistentDataType.STRING)
+        && "leave".equals(pdc.get(key, org.bukkit.persistence.PersistentDataType.STRING));
   }
+
+  public boolean leaveLocked() { return leaveLocked; }
 
   public ItemStack teamSelectorItem() { return teamSelector; }
   public ItemStack leaveItem() { return leaveItem; }

--- a/src/main/java/com/example/bedwars/lobby/LobbyListener.java
+++ b/src/main/java/com/example/bedwars/lobby/LobbyListener.java
@@ -23,14 +23,17 @@ public final class LobbyListener implements Listener {
   private final TeamSelectMenu teamSelectMenu;
   private final PlayerContextService contexts;
   private final GameService gameService;
+  private final LobbyService lobbyService;
 
   public LobbyListener(BedwarsPlugin plugin, LobbyItemsService items, TeamSelectMenu menu,
-                       PlayerContextService contexts, GameService gameService) {
+                       PlayerContextService contexts, GameService gameService,
+                       LobbyService lobbyService) {
     this.plugin = plugin;
     this.items = items;
     this.teamSelectMenu = menu;
     this.contexts = contexts;
     this.gameService = gameService;
+    this.lobbyService = lobbyService;
   }
 
   @EventHandler(ignoreCancelled = true)
@@ -58,7 +61,7 @@ public final class LobbyListener implements Listener {
     if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) return;
     Player p = e.getPlayer();
     if (contexts.getArena(p) == null) return;
-    gameService.leave(p, true);
+    lobbyService.sendToLobby(p, LobbyService.Reason.ITEM);
     e.setCancelled(true);
   }
 
@@ -70,7 +73,7 @@ public final class LobbyListener implements Listener {
     Arena a = plugin.arenas().get(arenaId).orElse(null);
     if (a == null || (a.state() != GameState.WAITING && a.state() != GameState.STARTING)) return;
     ItemStack it = e.getItemDrop().getItemStack();
-    if (items.isTeamSelector(it) || items.isLeaveItem(it)) e.setCancelled(true);
+    if (items.isTeamSelector(it) || (items.leaveLocked() && items.isLeaveItem(it))) e.setCancelled(true);
   }
 
   @EventHandler(ignoreCancelled = true)
@@ -81,6 +84,6 @@ public final class LobbyListener implements Listener {
     Arena a = plugin.arenas().get(arenaId).orElse(null);
     if (a == null || (a.state() != GameState.WAITING && a.state() != GameState.STARTING)) return;
     ItemStack it = e.getCurrentItem();
-    if (items.isTeamSelector(it) || items.isLeaveItem(it)) e.setCancelled(true);
+    if (items.isTeamSelector(it) || (items.leaveLocked() && items.isLeaveItem(it))) e.setCancelled(true);
   }
 }

--- a/src/main/java/com/example/bedwars/lobby/LobbyLocationService.java
+++ b/src/main/java/com/example/bedwars/lobby/LobbyLocationService.java
@@ -1,0 +1,61 @@
+package com.example.bedwars.lobby;
+
+import com.example.bedwars.BedwarsPlugin;
+import java.util.Optional;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+
+/** Manages the lobby location loaded from config. */
+public final class LobbyLocationService {
+  private final BedwarsPlugin plugin;
+  private Location location;
+
+  public LobbyLocationService(BedwarsPlugin plugin) {
+    this.plugin = plugin;
+    load();
+  }
+
+  public void load() {
+    FileConfiguration cfg = plugin.getConfig();
+    String world = cfg.getString("lobby.world", "");
+    if (world == null || world.isEmpty()) {
+      location = null;
+      return;
+    }
+    World w = Bukkit.getWorld(world);
+    if (w == null) {
+      location = null;
+      return;
+    }
+    double x = cfg.getDouble("lobby.x");
+    double y = cfg.getDouble("lobby.y");
+    double z = cfg.getDouble("lobby.z");
+    float yaw = (float) cfg.getDouble("lobby.yaw");
+    float pitch = (float) cfg.getDouble("lobby.pitch");
+    location = new Location(w, x, y, z, yaw, pitch);
+  }
+
+  public void save() {
+    if (location == null) return;
+    FileConfiguration cfg = plugin.getConfig();
+    cfg.set("lobby.world", location.getWorld().getName());
+    cfg.set("lobby.x", location.getX());
+    cfg.set("lobby.y", location.getY());
+    cfg.set("lobby.z", location.getZ());
+    cfg.set("lobby.yaw", location.getYaw());
+    cfg.set("lobby.pitch", location.getPitch());
+    plugin.saveConfig();
+  }
+
+  public Optional<Location> get() {
+    return Optional.ofNullable(location);
+  }
+
+  public void setFrom(Player p) {
+    this.location = p.getLocation().clone();
+    save();
+  }
+}

--- a/src/main/java/com/example/bedwars/lobby/LobbyService.java
+++ b/src/main/java/com/example/bedwars/lobby/LobbyService.java
@@ -1,0 +1,59 @@
+package com.example.bedwars.lobby;
+
+import com.example.bedwars.BedwarsPlugin;
+import com.example.bedwars.game.PreJoinSnapshotService;
+import com.example.bedwars.game.PlayerContextService;
+import java.util.Optional;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
+
+/** Handles teleporting players back to the lobby and cleaning their state. */
+public final class LobbyService {
+  public enum Reason { COMMAND, ITEM, DISCONNECT, GAME_END, OTHER }
+
+  private final BedwarsPlugin plugin;
+  private final PlayerContextService contexts;
+  private final LobbyLocationService location;
+  private final PreJoinSnapshotService snapshots;
+
+  public LobbyService(BedwarsPlugin plugin, PlayerContextService ctx,
+                      LobbyLocationService location, PreJoinSnapshotService snaps) {
+    this.plugin = plugin;
+    this.contexts = ctx;
+    this.location = location;
+    this.snapshots = snaps;
+  }
+
+  public void sendToLobby(Player p, Reason reason) {
+    // remove from arena if needed
+    String arenaId = contexts.getArena(p);
+    if (arenaId != null) {
+      plugin.game().leave(p, false);
+    }
+    sanitizePlayer(p);
+    Optional.ofNullable(location.get().orElse(null)).ifPresentOrElse(loc -> {
+      p.teleportAsync(loc);
+    }, () -> {
+      p.kick(org.bukkit.ChatColor.RED + "Lobby non configuré. /bwadmin lobby set");
+    });
+  }
+
+  private void sanitizePlayer(Player p) {
+    snapshots.restore(p);
+    for (PotionEffect eff : p.getActivePotionEffects()) {
+      p.removePotionEffect(eff.getType());
+    }
+    p.setAllowFlight(false);
+    p.setFlying(false);
+    p.setInvisible(false);
+    p.setGameMode(GameMode.SURVIVAL);
+    var mgr = Bukkit.getScoreboardManager();
+    if (mgr != null) p.setScoreboard(mgr.getMainScoreboard());
+    p.getInventory().setHeldItemSlot(0);
+  }
+
+  public LobbyLocationService location() { return location; }
+  public PreJoinSnapshotService snapshots() { return snapshots; }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -198,15 +198,26 @@ fireball:
   break_only_player_blocks: true
   cooldown_ticks: 20
 
+lobby:
+  world: world
+  x: 0.5
+  y: 80.0
+  z: 0.5
+  yaw: 0.0
+  pitch: 0.0
+
 items:
   team_selector:
     material: NETHER_STAR
     name: "&bSélecteur d’équipe"
     slot: 0
-  leave_arena:
-    material: OAK_DOOR
-    name: "&cQuitter l’arène"
+  leave:
+    material: DARK_OAK_DOOR
+    name: "&cQuitter l'arène"
+    lore:
+      - "&7Clique pour retourner au lobby"
     slot: 8
+    lock: true
 
 scoreboard:
   enabled: true

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -248,3 +248,10 @@ debug:
 maintenance:
   start: "&7[MAINT] cleanup &e{arena}&7..."
   done: "&a[CLEANUP] &f{arena}&a: removed=&f{count} &7{breakdown}"
+lobby:
+  set_ok: "&aLobby défini ici."
+  missing: "&cLobby non configuré. Faites &e/bwadmin lobby set&c."
+leave:
+  title: "&cVous avez quitté l'arène"
+  by_item: "&7Retour au lobby via l'item."
+  by_cmd: "&7Retour au lobby."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,9 +8,11 @@ commands:
     description: Commandes joueur BedWars
     aliases: [bedwars]
     usage: /bw <join|leave|team|menu>
+    permission: bedwars.player
   bwadmin:
     description: Commandes admin BedWars
     usage: /bwadmin <arena|game|menu>
+    permission: bedwars.admin
 permissions:
   bedwars.admin.*:
     description: Tous les droits BedWars
@@ -27,6 +29,12 @@ permissions:
       bedwars.admin.debug: true
       bedwars.admin.maintenance: true
       bedwars.admin.backup: true
+  bedwars.admin.lobby:
+    description: Set du lobby BedWars
+    default: op
+  bedwars.player:
+    description: Commandes joueur BedWars
+    default: true
   bedwars.menu.rules:
     description: Ouvrir le menu Règles via la boussole
     default: true


### PR DESCRIPTION
## Summary
- add lobby location and player snapshot services
- centralize lobby teleport and cleanup with door leave item
- expose commands and permissions for lobby configuration

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ddac1f4bc8329b005beef115e4867