### PR TITLE
feat: lobby waiting scoreboard

### DIFF
--- a/src/main/java/com/example/bedwars/BedwarsPlugin.java
+++ b/src/main/java/com/example/bedwars/BedwarsPlugin.java
@@ -58,6 +58,7 @@ public final class BedwarsPlugin extends JavaPlugin {
 
   private static BedwarsPlugin instance;
   private Messages messages;
+  private com.example.bedwars.util.ScoreboardConfig scoreboardConfig;
   private Keys keys;
   private ArenaManager arenaManager;
   private MenuManager menuManager;
@@ -95,6 +96,7 @@ public final class BedwarsPlugin extends JavaPlugin {
     instance = this;
     saveDefaultConfig();
     this.messages = new Messages(this);
+    this.scoreboardConfig = new com.example.bedwars.util.ScoreboardConfig(this);
     this.keys = new Keys(this);
     this.arenaManager = new ArenaManager(this);
     this.arenaManager.loadAll();
@@ -146,8 +148,9 @@ public final class BedwarsPlugin extends JavaPlugin {
       this.actionBarBus.start(this);
     }
     this.scoreboardManager = new com.example.bedwars.hud.ScoreboardManager(this);
-    if (getConfig().getBoolean("scoreboard.enabled", true)) {
-      org.bukkit.Bukkit.getScheduler().runTaskTimer(this, () -> scoreboardManager.tick(), 20L, 20L);
+    if (scoreboardConfig.enabled()) {
+      long period = Math.min(scoreboardConfig.refreshRunningTicks(), scoreboardConfig.refreshWaitingTicks());
+      org.bukkit.Bukkit.getScheduler().runTaskTimer(this, () -> scoreboardManager.tick(), 20L, period);
     }
 
     Objects.requireNonNull(getCommand("bw")).setExecutor(new BwCommand(this));
@@ -241,6 +244,7 @@ public final class BedwarsPlugin extends JavaPlugin {
   public LightingService lighting() { return lightingService; }
   public BuildRulesService buildRules() { return buildRules; }
   public com.example.bedwars.hud.ScoreboardManager scoreboard() { return scoreboardManager; }
+  public com.example.bedwars.util.ScoreboardConfig scoreboardCfg() { return scoreboardConfig; }
   public com.example.bedwars.hud.ActionBarBus actionBar() { return actionBarBus; }
   public RotationManager rotation() { return rotationManager; }
   public ResetManager reset() { return resetManager; }

--- a/src/main/java/com/example/bedwars/util/ScoreboardConfig.java
+++ b/src/main/java/com/example/bedwars/util/ScoreboardConfig.java
@@ -1,0 +1,52 @@
+package com.example.bedwars.util;
+
+import com.example.bedwars.BedwarsPlugin;
+import java.io.File;
+import java.util.List;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+/** Configuration holder for scoreboard settings. */
+public final class ScoreboardConfig {
+  private final FileConfiguration cfg;
+
+  public ScoreboardConfig(BedwarsPlugin plugin) {
+    File f = new File(plugin.getDataFolder(), "scoreboard.yml");
+    if (!f.exists()) {
+      plugin.saveResource("scoreboard.yml", false);
+    }
+    this.cfg = YamlConfiguration.loadConfiguration(f);
+  }
+
+  public boolean enabled() {
+    return cfg.getBoolean("scoreboard.enabled", true);
+  }
+
+  public int refreshWaitingTicks() {
+    return cfg.getInt("scoreboard.refresh_waiting_ticks", 20);
+  }
+
+  public int refreshRunningTicks() {
+    return cfg.getInt("scoreboard.refresh_running_ticks", 20);
+  }
+
+  public String waitingTitle() {
+    return cfg.getString("scoreboard.waiting.title", "&6BedWars");
+  }
+
+  public List<String> waitingLines() {
+    return cfg.getStringList("scoreboard.waiting.lines");
+  }
+
+  public int tipsRotateSeconds() {
+    return cfg.getInt("scoreboard.tips.rotate_seconds", 5);
+  }
+
+  public List<String> tipsPool() {
+    return cfg.getStringList("scoreboard.tips.pool");
+  }
+
+  public String footer() {
+    return cfg.getString("scoreboard.footer", "");
+  }
+}

--- a/src/main/resources/scoreboard.yml
+++ b/src/main/resources/scoreboard.yml
@@ -1,0 +1,24 @@
+scoreboard:
+  enabled: true
+  refresh_waiting_ticks: 20
+  refresh_running_ticks: 20
+  waiting:
+    title: "&6BedWars &e{mode_name}"
+    lines:
+      - " "
+      - "&fSalle d'attente"
+      - "&7- Joueurs: &b{players}&7/&f{max_players}"
+      - "&7- D\u00e9marrage: &e{start_seconds}s"
+      - "&7- Mode: &6{mode_name}"
+      - "&7- Carte: &d{map_name}"
+      - " "
+      - "{tip_line_1}"
+      - "{tip_line_2}"
+      - " "
+      - "{footer}"
+  tips:
+    rotate_seconds: 5
+    pool:
+      - "&7Chapitre &e3&7/&f100"
+      - "&7Parler au PNJ &eCosm\u00e9tique &7dans le lobby"
+  footer: "&6rinaorc.com"


### PR DESCRIPTION
## Summary
- add configurable waiting scoreboard with tips and footer
- expose countdown data for arenas
- load scoreboard settings from new `scoreboard.yml`

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dde036fe08329b763915b51e94955