### PR TITLE
Guard against missing potion flags and enchant constants

### DIFF
--- a/src/main/java/com/example/bedwars/shop/PotionUtil.java
+++ b/src/main/java/com/example/bedwars/shop/PotionUtil.java
@@ -3,6 +3,7 @@ package com.example.bedwars.shop;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
 
@@ -10,12 +11,29 @@ import org.bukkit.potion.PotionData;
 public final class PotionUtil {
   private PotionUtil() {}
 
+  /**
+   * Tries to apply the {@code HIDE_POTION_EFFECTS} flag if the running server
+   * supports it. Some API builds omit the constant which would otherwise throw
+   * an {@link IllegalArgumentException} during compilation.
+   */
+  public static void tryHidePotionEffects(ItemMeta meta) {
+    if (meta == null) return;
+    try {
+      ItemFlag flag = ItemFlag.valueOf("HIDE_POTION_EFFECTS");
+      meta.addItemFlags(flag);
+    } catch (IllegalArgumentException ignored) {
+      // Flag not present on this distribution; ignore silently.
+    }
+  }
+
   public static ItemStack mkPotion(PotionSpec spec) {
     ItemStack it = new ItemStack(Material.POTION);
     PotionMeta pm = (PotionMeta) it.getItemMeta();
     if (pm != null && spec != null) {
+      // TODO: replace deprecated PotionData usage with PDC-based handling on
+      // consumption via PlayerItemConsumeEvent.
       pm.setBasePotionData(new PotionData(spec.type(), false, spec.amplifier() > 1));
-      pm.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
+      tryHidePotionEffects(pm);
       it.setItemMeta(pm);
     }
     return it;

--- a/src/main/java/com/example/bedwars/shop/UpgradesGui.java
+++ b/src/main/java/com/example/bedwars/shop/UpgradesGui.java
@@ -25,10 +25,15 @@ import java.util.Map;
  */
 public final class UpgradesGui {
   private final BedwarsPlugin plugin;
-  private static final Enchantment GLOW_ENCH =
-      Enchantment.getByKey(NamespacedKey.minecraft("power")) != null
-          ? Enchantment.getByKey(NamespacedKey.minecraft("power"))
-          : Enchantment.DURABILITY;
+
+  private static Enchantment resolveGlow() {
+    Enchantment e = Enchantment.getByKey(NamespacedKey.minecraft("unbreaking"));
+    if (e == null) e = Enchantment.getByKey(NamespacedKey.minecraft("mending"));
+    if (e == null) e = Enchantment.getByKey(NamespacedKey.minecraft("protection"));
+    return e; // may remain null; callers should check
+  }
+
+  private static final Enchantment GLOW_ENCH = resolveGlow();
 
   // layout slots according to spec
   public static final int SLOT_DIAMOND_COUNTER = 8;
@@ -93,7 +98,7 @@ public final class UpgradesGui {
         String lore = (have >= cost ? ChatColor.GRAY : ChatColor.RED) + plugin.messages().format("upgrades.cost", Map.of("cost", cost));
         im.setLore(java.util.List.of(lore));
       } else {
-        im.addEnchant(GLOW_ENCH, 1, true);
+        if (GLOW_ENCH != null) im.addEnchant(GLOW_ENCH, 1, true);
         im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         im.setLore(java.util.List.of(ChatColor.GREEN + plugin.messages().get("upgrades.max")));
       }


### PR DESCRIPTION
## Summary
- add optional ItemFlag detection to hide potion effects without breaking builds
- resolve glow enchant by key instead of using removed DURABILITY constant

## Testing
- `mvn -q package` *(fails: could not transfer artifact due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689deece46f48329bb4ed75402238084