### PR TITLE
Remove Adventure dependency and update 1.21 potion constants

### DIFF
--- a/src/main/java/com/example/bedwars/shop/PotionConsumeListener.java
+++ b/src/main/java/com/example/bedwars/shop/PotionConsumeListener.java
@@ -30,7 +30,7 @@ public final class PotionConsumeListener implements Listener {
     Player p = e.getPlayer();
     switch (id) {
       case "SPEED2_45" -> p.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 45*20, 1, true, false, false));
-      case "JUMP5_45" -> p.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 45*20, 4, true, false, false));
+      case "JUMP5_45" -> p.addPotionEffect(new PotionEffect(PotionEffectType.JUMP_BOOST, 45*20, 4, true, false, false));
       case "INVIS_30" -> p.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, 30*20, 0, true, false, false));
       default -> {}
     }

--- a/src/main/java/com/example/bedwars/shop/PotionUtil.java
+++ b/src/main/java/com/example/bedwars/shop/PotionUtil.java
@@ -1,6 +1,5 @@
 package com.example.bedwars.shop;
 
-import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -22,7 +21,7 @@ public final class PotionUtil {
     ItemStack it = new ItemStack(Material.POTION);
     PotionMeta pm = (PotionMeta) it.getItemMeta();
     if (pm != null) {
-      pm.displayName(Component.text(ChatColor.translateAlternateColorCodes('&', display)));
+      pm.setDisplayName(ChatColor.translateAlternateColorCodes('&', display));
       try {
         pm.addItemFlags(ItemFlag.valueOf("HIDE_POTION_EFFECTS"));
       } catch (IllegalArgumentException ignored) {


### PR DESCRIPTION
## Summary
- remove remaining Adventure `Component` usage in potion utility
- use Spigot's `setDisplayName` and keep optional potion effect hiding
- update jump potion to `JUMP_BOOST` for 1.21

## Testing
- `mvn -q clean package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin:pom:3.2.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_689f54eb6a1483298112e32af3c6e1f0